### PR TITLE
Minor error in crontab explorer when user has no crontab during the probe

### DIFF
--- a/conf/type/__crontab/explorer/crontab
+++ b/conf/type/__crontab/explorer/crontab
@@ -24,4 +24,4 @@
 user="$(cat "$__object/parameter/user")"
 line="$(cat "$__object/parameter/line")"
 
-crontab -l -u "$user"
+crontab -l -u "$user" 2>/dev/null || __cdist_echo warn "No crontab for '$user'"


### PR DESCRIPTION
Hi Nico,

While testing your "crontab" fork, I noticed that the explorer fails when the user has no previous crontab. This is due to the "set -e" option in the shell. I turned the "crontab -l ..." command into a list using '||' and now it doesn't bail out prematurely. 

Please take a look at the commit.

Sincerely,

Scott
