### PR TITLE
new type: __rsyncer

### DIFF
--- a/conf/type/__rsyncer/gencode-local
+++ b/conf/type/__rsyncer/gencode-local
@@ -19,7 +19,12 @@
 #
 
 source="$(cat "$__object/parameter/source")"
-destination="$(cat "$__object/parameter/destination")"
+
+if [ -f "$__object/parameter/destination" ]; then
+    destination="$(cat "$__object/parameter/destination")"
+else
+    destination="/$__object_id"
+fi
 
 # The system binary is probably ok, but if not...
 if [ -f "$__object/parameter/rsyncbin" ]; then

--- a/conf/type/__rsyncer/man.text
+++ b/conf/type/__rsyncer/man.text
@@ -23,12 +23,13 @@ source::
     The full path of the source from which to copy. This is passed directly
     to rsync.
 
-destination::
-    The full path of the destination. This is passed directly to rsync.
-
 
 OPTIONAL PARAMETERS
 -------------------
+destination::
+    The full path of the destination. This is passed directly to rsync.
+    Default: object_id
+
 delete::
     If true, remove files from destination which are not in source. This is
     effectively the --delete argument of rsync.
@@ -43,6 +44,9 @@ EXAMPLES
 
 --------------------------------------------------------------------------------
 # Basic example
+__rsyncer '/home/foo' --source '/opt/dist/foo'
+
+# Fancier example
 __rsyncer FOO --source '/opt/dist/foo' --destination '/home/foo/' --delete true
 --------------------------------------------------------------------------------
 

--- a/conf/type/__rsyncer/parameter/optional
+++ b/conf/type/__rsyncer/parameter/optional
@@ -1,2 +1,3 @@
+destination
 delete
 rsyncbin

--- a/conf/type/__rsyncer/parameter/required
+++ b/conf/type/__rsyncer/parameter/required
@@ -1,2 +1,1 @@
 source
-destination


### PR DESCRIPTION
This type is used to trigger rsync to copy files from the machine running cdist (source) to the target machine in question (destination). The likely usage is the rapid deployment of full directory trees, the cohorency of which can be guarunteed with the optional `--delete` argument, which will remove any files from the destination which are not present on the source.

While it would be trivial to expand it to use more of rsync's features, I suspect that keeping it simple fits in more closely with the design ethos of cdist.
