### PR TITLE
Add note about leading /'s in __object_id

### DIFF
--- a/doc/man/cdist-reference.text.sh
+++ b/doc/man/cdist-reference.text.sh
@@ -180,6 +180,7 @@ __object::
 __object_id::
    The type unique object id.
    Available for: type manifest, type explorer, type gencode
+   Note: The leading "/" will always be stripped.
 __self::
    DEPRECATED: Same as __object_name, do not use anymore, use __object_name instead.
    Will be removed in cdist 3.x.


### PR DESCRIPTION
Only because it's not mentioned else where :)
I had thought about adding more, i.e. the reason why, but left it out in the end as it didn't feel like the right place to put that info.
