### PR TITLE
bugfix - do chmod last

### DIFF
--- a/conf/type/__file/gencode-remote
+++ b/conf/type/__file/gencode-remote
@@ -34,11 +34,6 @@ case "$state_should" in
          fi
       fi
 
-      # Mode settings
-      if [ -f "$__object/parameter/mode" ]; then
-         echo chmod \"$(cat "$__object/parameter/mode")\" \"$destination\"
-      fi
-
       # Group
       if [ -f "$__object/parameter/group" ]; then
          echo chgrp \"$(cat "$__object/parameter/group")\" \"$destination\"
@@ -47,6 +42,12 @@ case "$state_should" in
       # Owner
       if [ -f "$__object/parameter/owner" ]; then
          echo chown \"$(cat "$__object/parameter/owner")\" \"$destination\"
+      fi
+
+      # Mode - needs to happen last as a chown/chgrp can alter mode by
+      # clearing S_ISUID and S_ISGID bits (see chown(2))
+      if [ -f "$__object/parameter/mode" ]; then
+         echo chmod \"$(cat "$__object/parameter/mode")\" \"$destination\"
       fi
    ;;
 


### PR DESCRIPTION
This came up in my testing of the larger __file type changes being discussed.  We need to do chmod after chown/chgrp because chown/chgrp can clear the S_ISUID or S_ISGID bits if they're set on an executable file.

This behavior does not appear to apply to directories so I did not change the order there.
