### PR TITLE
bugfix for shadow field number

### DIFF
--- a/conf/type/__user/gencode-remote
+++ b/conf/type/__user/gencode-remote
@@ -42,7 +42,7 @@ if grep -q "^${name}:" "$__object/explorer/passwd"; then
             fi
          ;;
          password)
-            field=3
+            field=2
             file="$__object/explorer/shadow"
          ;;
          comment) field=5 ;;


### PR DESCRIPTION
Field number for the password entry in shadow explorer output is 2, not 3
