### PR TITLE
fix for changing a user's group by name

### DIFF
--- a/conf/type/__user/gencode-remote
+++ b/conf/type/__user/gencode-remote
@@ -37,14 +37,15 @@ if grep -q "^${name}:" "$__object/explorer/passwd"; then
             if $(echo "$new_value" | grep -q '^[0-9][0-9]*$'); then
                field=4
             else
-               # we were passed a group name.  compare to current gid and
-               # set $current_value to $oldgid if it needs changing.
-               newgid=$(awk -F: '{ print $3 }' "$__object/explorer/group")
-               oldgid=$(awk -F: '{ print $4 }' "$file")
-               if [ "$newgid" != "$oldgid" ]; then
-                  current_value="$oldgid"
+               # We were passed a group name.  Compare the gid in
+               # the user's /etc/passwd entry with the gid of the
+               # group returned by the group explorer.
+               gid_from_group=$(awk -F: '{ print $3 }' "$__object/explorer/group")
+               gid_from_passwd=$(awk -F: '{ print $4 }' "$file")
+               if [ "$gid_from_group" != "$gid_from_passwd" ]; then
+                  current_value="$gid_from_passwd"
                else
-                  current_value=$new_value
+                  current_value="$new_value"
                fi
             fi
          ;;
@@ -58,6 +59,8 @@ if grep -q "^${name}:" "$__object/explorer/passwd"; then
          uid)     field=3 ;;
       esac
 
+      # If we haven't already set $current_value above, pull it from the
+      # appropriate file/field.
       if [ -z "$current_value" ]; then
          export field
          current_value="$(awk -F: '{ print $ENVIRON["field"] }' < "$file")"


### PR DESCRIPTION
There appears to be a bug where the logic in __user/gencode-remote does not correctly identify that a user's group needs updating when --gid is passed by name. To reproduce the current bug, here is a manifest:

<pre>__user foo --uid 1415 --gid foo</pre>


When the following exists in /etc/passwd:

<pre>foo:x:1415:100:Foo User:/home/foo:/sbin/nologin</pre>


And the following in /etc/group (i.e. foo's current group is NOT correct and cdist needs to fix it):

<pre>foo:x:1415:</pre>
