### PR TITLE
reference doc: fix environment variable list to be properly displayed

### DIFF
--- a/doc/man/cdist-reference.text.sh
+++ b/doc/man/cdist-reference.text.sh
@@ -188,6 +188,7 @@ __object_id::
     the filesystem database and ensured by the core).
 
     Note: Double slashes ("//") will not be fixed and result in an error.
+
 __self::
     DEPRECATED: Same as __object_name, do not use anymore, use __object_name instead.
     Will be removed in cdist 3.x.


### PR DESCRIPTION
Prevent nesting of blockquotes below __object_id, preventing the
following environment variables from being displayed as list items.

Signed-off-by: Giel van Schijndel <giel+cdist@mortis.eu>
