### PR TITLE
added -h option to ln when creating a link

### DIFF
--- a/conf/type/__link/gencode-remote
+++ b/conf/type/__link/gencode-remote
@@ -28,7 +28,7 @@ source="$(cat "$__object/parameter/source")"
 
 case "$type" in
    symbolic)
-      lnopt="-s"
+      lnopt="-s -h"
    ;;
    hard)
       lnopt=""


### PR DESCRIPTION
imagine:

> ls
> ./dirA
> 
> ls ./dirA
> // nothing in here
> 
> ln -s -f dirA link
> 
> ls
> ./dirA
> ./link -> dirA

now cdist runs again and would execute 'ln -s -f dirA link' again...

> ln -s -f dirA link
> 
> ls
> ./dirA
> ./link -> dirA
> 
> ls ./dirA
> link -> dirA
> // now suddenly we have this link to dirA in here

using 'ln -s -f -h dirA link' prevents this from happening
