### PR TITLE
Ensure user/group in __ssh_authorized_key

### DIFF
--- a/conf/type/__ssh_authorized_key/man.text
+++ b/conf/type/__ssh_authorized_key/man.text
@@ -22,6 +22,8 @@ OPTIONAL PARAMETERS
 -------------------
 srcuser:: the user to take the rsa public key from
 dstuser:: the user to give the rsa public key to
+dstgroup:: the group to assign ownership of the authorized_keys file to.
+defaults to dstuser
 
 
 EXAMPLES
@@ -32,6 +34,11 @@ EXAMPLES
 __ssh_authorized_key admin
 #deploy bob's public key to alice's authorized_keys
 __ssh_authorized_key --srcuser bob --dstuser alice
+#deploy bob's key to a alice in group users
+__ssh_authorized_key otherkey \
+    --srcuser bob \
+    --dstuser alice \
+    --dstgroup users
 --------------------------------------------------------------------------------
 
 

--- a/conf/type/__ssh_authorized_key/manifest
+++ b/conf/type/__ssh_authorized_key/manifest
@@ -30,6 +30,11 @@ fi
 if [ -f "$__object/parameter/dstuser" ]; then
    dstuser=`cat "$__object/parameter/dstuser"`
 fi
+# Get option dstgroup if defined
+if [ -f "$__object/parameter/dstgroup" ]; then
+   dstgroup=`cat "$__object/parameter/dstgroup"`
+fi
+
 
 # if a source user is defined, use it's public key
 if [ "$srcuser" ]; then
@@ -41,14 +46,26 @@ fi
 # if a destination user is defined, insert in it's authorized_keys
 if [ "$dstuser" ]; then
    sshpath="/home/$dstuser/.ssh"
+   if [ ! "$dstgroup" ]; then
+       dstgroup=${dstuser}
+   fi
 # if no destination user is defined we use root's home
 else
    sshpath="/root/.ssh"
+   dstuser="root"
+   dstgroup="root"
 fi
 rsa=`cat $srcrsa`
-__directory $sshpath
+__directory $sshpath \
+    --owner $dstuser \
+    --group $dstgroup \
+    --mode 700
 # the file authorized_keys depends on the .ssh folder
-require="__directory${sshpath}" __file "$sshpath/authorized_keys" --mode 640
+require="__directory${sshpath}" \
+    __file "$sshpath/authorized_keys" \
+    --mode 640 \
+    --owner $dstuser \
+    --group $dstgroup
 # the line added depends on authorized_keys existence
 require="__file${sshpath}/authorized_keys" __addifnosuchline sshkey --file \
  "$sshpath/authorized_keys" --line "$rsa"

--- a/conf/type/__ssh_authorized_key/parameter/optional
+++ b/conf/type/__ssh_authorized_key/parameter/optional
@@ -1,2 +1,3 @@
 srcuser
 dstuser
+dstgroup


### PR DESCRIPTION
Add --dstgroup option to set group on authorized_keys file.

Also, set user of authorized_keys to match dstuser so it is
not owned by root.
