### PR TITLE
inherit dependencies from defining object when setting up implicit depen...

### DIFF
--- a/lib/cdist/emulator.py
+++ b/lib/cdist/emulator.py
@@ -160,10 +160,19 @@ class Emulator(object):
     def record_auto_requirements(self):
         """An object shall automatically depend on all objects that it defined in it's type manifest.
         """
-        # __object_name is the name of the object whose type manifest is currenlty executed
+        # __object_name is the name of the object whose type manifest is currently executed
         __object_name = os.environ.get('__object_name', None)
         if __object_name:
-            _object = self.cdist_object.object_from_name(__object_name)
-            # prevent circular dependencies
-            if not _object.name in self.cdist_object.requirements:
-                _object.requirements.append(self.cdist_object.name)
+            # The object whose type manifest is currently run
+            parent = self.cdist_object.object_from_name(__object_name)
+            # The object currently being defined
+            current_object = self.cdist_object
+            # current_object shall have all dependencies that it's parent has
+            for req in parent.requirements:
+                if req not in current_object.requirements:
+                    current_object.requirements.append(req)
+            # As parent defined current_object it shall automatically depend on it.
+            # But only if the user hasn't said otherwise.
+            # Must prevent circular dependencies.
+            if not parent.name in current_object.requirements:
+                parent.requirements.append(current_object.name)


### PR DESCRIPTION
...dencies through autorequire

Fixes the following problem:

__package/a autorequire on __package_specific/a
__package/b autorequire on __package_specific/b
__package/b require on __package/a

is:

``` python
{'__package/a': [<CdistObject __package_pacman/a>, <CdistObject __package/a>],
 '__package/b': [<CdistObject __package_pacman/a>,
                 <CdistObject __package/a>,
                 <CdistObject __package_pacman/b>,
                 <CdistObject __package/b>],
 '__package_pacman/a': [<CdistObject __package_pacman/a>],
 '__package_pacman/b': [<CdistObject __package_pacman/b>]}
```

The problem is that __package_pacman/a and __package_pacman/b have no relation.
But __package_pacman/b should depend on __package/a.

should:

``` python
{'__package/a': [<CdistObject __package_pacman/a>, <CdistObject __package/a>],
 '__package/b': [<CdistObject __package_pacman/a>,
                 <CdistObject __package/a>,
                 <CdistObject __package_pacman/b>,
                 <CdistObject __package/b>],
 '__package_pacman/a': [<CdistObject __package_pacman/a>],
 '__package_pacman/b': [<CdistObject __package_pacman/a>, <CdistObject __package/a>, <CdistObject __package_pacman/b>]}
```

Signed-off-by: Steven Armstrong steven@icarus.ethz.ch
