### PR TITLE
set safe permissions on remote base_dir (/var/lib/cdist)

### DIFF
--- a/lib/cdist/exec/remote.py
+++ b/lib/cdist/exec/remote.py
@@ -59,7 +59,7 @@ class Remote(object):
 
     def create_directories(self):
         self.rmdir(self.base_path)
-        self.mkdir(self.base_path)
+        self.mkdir(self.base_path, mode=0o700)
         self.mkdir(self.conf_path)
 
     def rmdir(self, path):
@@ -67,10 +67,11 @@ class Remote(object):
         self.log.debug("Remote rmdir: %s", path)
         self.run(["rm", "-rf",  path])
 
-    def mkdir(self, path):
+    def mkdir(self, path, mode=0o755):
         """Create directory on the remote side."""
         self.log.debug("Remote mkdir: %s", path)
         self.run(["mkdir", "-p", path])
+        self.run(["chmod", "%o" % mode, path])
 
     def transfer(self, source, destination):
         """Transfer a file or directory to the remote side."""


### PR DESCRIPTION
currently:
# ls -ald /var/lib/cdist

drwxr-xr-x 4 root root 96 Apr 25 17:16 /var/lib/cdist

with this patch:
# ls -ald /var/lib/cdist

drwx------ 4 root root 4096 2012-04-30 14:41 /var/lib/cdist

I believe we already fixed this in the 'cdist-pure-shell' days, but it seems we missed it while porting to python. I would consider this a severe issue. Maybe you should deploy and announce a security bugfix release after merging.

Signed-off-by: Steven Armstrong steven@icarus.ethz.ch
