### PR TITLE
Freenode.net, not freenode.org.

### DIFF
--- a/README
+++ b/README
@@ -259,7 +259,7 @@ need to replace **\_\_file** calls in your manifests:
 ### IRC
 
 You can join the development ***IRC channel***
-[#cstar on irc.freenode.org](irc://irc.freenode.org/#cstar).
+[#cstar on irc.freenode.net](irc://irc.freenode.org/#cstar).
 
 ### Mailing list
 


### PR DESCRIPTION
Signed-off-by: Chris Lamb lamby@debian.org
