### PR TITLE
Ensure __ssh_authorized_key sets proper group

### DIFF
--- a/conf/type/__ssh_authorized_key/explorer/dstuser_group
+++ b/conf/type/__ssh_authorized_key/explorer/dstuser_group
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Get option dstuser if defined
+if [ -f "$__object/parameter/dstuser" ]; then
+   dstuser=`cat "$__object/parameter/dstuser"`
+else
+   dstuser="root"
+fi
+
+if id $dstuser >/dev/null 2>&1 ; then
+    id -ng $dstuser
+else
+   echo "$__object_id: Destination user $dstuser does not exist" >&2
+   exit 1
+fi

--- a/conf/type/__ssh_authorized_key/manifest
+++ b/conf/type/__ssh_authorized_key/manifest
@@ -29,7 +29,12 @@ fi
 # Get option dstuser if defined
 if [ -f "$__object/parameter/dstuser" ]; then
    dstuser=`cat "$__object/parameter/dstuser"`
+else
+   dstuser="root"
 fi
+
+# retrieve destination group
+dstgroup=$(cat "$__object/explorer/dstuser_group")
 
 # if a source user is defined, use it's public key
 if [ "$srcuser" ]; then
@@ -46,9 +51,16 @@ else
    sshpath="/root/.ssh"
 fi
 rsa=`cat $srcrsa`
-__directory $sshpath
+__directory $sshpath \
+    --owner $dstuser \
+    --group $dstgroup \
+    --mode 700
 # the file authorized_keys depends on the .ssh folder
-require="__directory${sshpath}" __file "$sshpath/authorized_keys" --mode 640
+require="__directory${sshpath}" \
+    __file "$sshpath/authorized_keys" \
+    --mode 640 \
+    --owner $dstuser \
+    --group $dstgroup
 # the line added depends on authorized_keys existence
 require="__file${sshpath}/authorized_keys" __addifnosuchline sshkey --file \
  "$sshpath/authorized_keys" --line "$rsa"


### PR DESCRIPTION
When --dstuser is specified, use an explorer to retrieve
the group name and specify the group name on all created
directories and files.

This is my second try, hopefully I have properly incorporated
your feedback from the first attempt.
