### PR TITLE
Shorten option for both useradd and usermod.

### DIFF
--- a/conf/type/__user/gencode-remote
+++ b/conf/type/__user/gencode-remote
@@ -28,7 +28,7 @@ name="$__object_id"
 # systems (such as *BSD, Darwin) those commands do not handle GNU style long
 # options.
 shorten_property() {
-    local ret=""
+    unset ret
     case "$1" in
 	comment) ret="-c";;
 	home) ret="-d";;
@@ -84,8 +84,7 @@ if grep -q "^${name}:" "$__object/explorer/passwd"; then
       fi
 
       if [ "$new_value" != "$current_value" ]; then
-	  local option=$(shorten_property $property)
-          set -- "$@" "$option" \'$new_value\'
+          set -- "$@" "$(shorten_property $property)" \'$new_value\'
       fi
    done
 
@@ -97,8 +96,7 @@ if grep -q "^${name}:" "$__object/explorer/passwd"; then
 else
    for property in $(ls .); do
       new_value="$(cat "$property")"
-      local option=$(shorten_property $property)
-      set -- "$@" "$option" \'$new_value\'
+      set -- "$@" "$(shorten_property $property)" \'$new_value\'
    done
 
    echo useradd "$@" "$name"


### PR DESCRIPTION
We need to shorten options for both usermod and useradd since on some
systems (such as *BSD, Darwin) those commands do not handle GNU style long
options.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>
