### PR TITLE
Don't symlink multiple times

### DIFF
--- a/conf/type/__jail/gencode-remote
+++ b/conf/type/__jail/gencode-remote
@@ -185,10 +185,12 @@ cat <<EOF
       if [ ! -d "${jaildir}/base/usr/home" ]; then
          mkdir -p "${jaildir}/base/usr/home"
       fi
-      if [ ! -d "${jaildir}/home" ]; then
-          SAVE=\$PWD; cd ${jaildir}/base
-          ln -s usr/home home
-          cd \$SAVE; unset SAVE
+      if [ ! -d "${jaildir}/base/home" ]; then
+          if [ ! -L "${jaildir}/base/home" ]; then
+             SAVE=\$PWD; cd ${jaildir}/base
+             ln -s usr/home home
+             cd \$SAVE; unset SAVE
+          fi
       fi
    fi
    if [ ! -d "${jaildir}/rw" ]; then


### PR DESCRIPTION
Was checking for existence of $jaildir/home -- never exists; will always create new symlink (winds up getting nested, causing problems)
Changed to look for directory or symlink at $jaildir/base/home and respond accordingly
