### PR TITLE
Eliminiate excess output from machine explorer

### DIFF
--- a/cdist/conf/explorer/machine
+++ b/cdist/conf/explorer/machine
@@ -22,6 +22,6 @@
 #
 #
 
-if command -v uname; then
+if command -v uname 2>&1 >/dev/null; then
    uname -m
 fi


### PR DESCRIPTION
command -v emits a string to stdout, silence this since we are only
interested in the return code.
