### PR TITLE
Bootstrap creates new repository, not a "bare" one

### DIFF
--- a/docs/man/man7/cdist-bootstrap.text
+++ b/docs/man/man7/cdist-bootstrap.text
@@ -98,7 +98,7 @@ example shows how to publish the configuration to another host that is
 reachable via ssh and has git installed:
 
 --------------------------------------------------------------------------------
-# Create bare git repository on the host named "loch"
+# Create new git repository on the host named "loch"
 cdist% ssh loch "GIT_DIR=/home/nutzer/cdist git init"
 Initialized empty Git repository in /home/nutzer/cdist/
 


### PR DESCRIPTION
"Bare" repositories are a special thing in Git, specifically, they're repositories with no working tree, instead just having the contents of `.git`.

The bootstrap document says it's creating a "bare" repository, but it appears to just be creating a plain new Git repository. This commit changes the naming to be "new", to remove any confusion for people who know about bare Git repositories.
