### PR TITLE
crontab -l should be allowed to fail with "no crontab" without failing

### DIFF
--- a/cdist/conf/type/__cron/gencode-remote
+++ b/cdist/conf/type/__cron/gencode-remote
@@ -38,7 +38,7 @@ if [ "$state_is" != "$state_should" ]; then
       present)
          cat << DONE
 tmp=\$($mktemp)
-crontab -u $user -l > \$tmp
+crontab -u $user -l > \$tmp || true
 cat >> \$tmp << EOC
 $(cat "$__object/parameter/entry")
 EOC


### PR DESCRIPTION
crontab -l may return failure error code stopping the code execution if the crontab does not exist, this behavior is not desired so this patch ignores the failure of that particular command
