### PR TITLE
add example of using non-root user with sudo

### DIFF
--- a/other/examples/remote/sudo/copy
+++ b/other/examples/remote/sudo/copy
@@ -1,0 +1,51 @@
+#!/bin/sh
+#
+# 2012 Matt Coddington (mcoddington at gmail.com)
+# 2012 Steven Armstrong (steven-cdist at armstrong.cc)
+# 2013 Chase Allen James (nx-cdist at nu-ex.com)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+# Use rsync over ssh to copy files.  Uses the "--rsync-path" option
+# to run the remote rsync instance with sudo.
+#
+# This command assumes your ssh configuration is already set up
+# in ~/.ssh/config.
+#
+# Usage:
+#  cdist config --remote-copy /path/to/this/script target_host
+#
+
+# For rsync to do the right thing, the source has to end with "/" if it is
+# a directory. The below preprocessor loop takes care of that.
+
+# second last argument is the source
+source_index=$(($#-1))
+index=0
+for arg in $@; do
+   if [ $index -eq 0 ]; then
+      # reset $@
+      set --
+   fi
+   index=$((index+=1))
+   if [ $index -eq $source_index -a -d "$arg" ]; then
+      arg="${arg%/}/"
+   fi
+   set -- "$@" "$arg"
+done
+
+rsync --copy-links --rsync-path="sudo rsync" -e 'ssh' "$@"

--- a/other/examples/remote/sudo/exec
+++ b/other/examples/remote/sudo/exec
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# 2013 Chase Allen James (nx-cdist at nu-ex.com)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+# Prefixes all remote commands with sudo.
+#
+# This command assumes your ssh configuration is already set up
+# in ~/.ssh/config.
+#
+# Usage:
+#  cdist config --remote-exec "/path/to/this/script" target_host
+#
+
+host="$1"; shift
+ssh -q "$host" sudo "$@"


### PR DESCRIPTION
Added copy and exec example of using cdist in the case that the remote user is not root and must use sudo to elevate to root privileges.

Especially useful when provisioning AWS with the default ubuntu image.
