### PR TITLE
fix auto-generating the version file

### DIFF
--- a/build-helper
+++ b/build-helper
@@ -300,7 +300,7 @@ eof
         fi
     ;;
     version)
-        git describe > cdist/version.py
+        echo "VERSION = \"$(git describe)\"" > cdist/version.py
     ;;
 
     *)


### PR DESCRIPTION
After the latest commit, I was getting an error when trying to run cdist. It looks like there was some code missing when build-helper tried to generate the version.py file.
