### PR TITLE
some __git fixes (quoting variables and manpage additions)

### DIFF
--- a/cdist/conf/type/__git/gencode-remote
+++ b/cdist/conf/type/__git/gencode-remote
@@ -51,12 +51,12 @@ case $state_should in
         if [ "$state_should" != "$state_is" ]; then
             echo git clone --quiet --branch "$branch" "$source" "$destination"
         fi
-        if [ \( -n ${owner} -a "$owner_is" != "$owner" \) -o \
-             \( -n ${group} -a "$group_is" != "$group" \) ]; then
-            echo chown -R ${owner}:${group} ${destination}
+        if [ \( -n "$owner" -a "$owner_is" != "$owner" \) -o \
+             \( -n "$group" -a "$group_is" != "$group" \) ]; then
+            echo chown -R "${owner}:${group}" "$destination"
         fi
-        if [ -n ${mode} ]; then
-            echo chmod -R ${mode} ${destination}
+        if [ -n "$mode" ]; then
+            echo chmod -R "$mode" "$destination"
         fi
     ;;
     # Handled in manifest

--- a/cdist/conf/type/__git/man.text
+++ b/cdist/conf/type/__git/man.text
@@ -27,6 +27,15 @@ state::
 branch::
     Create this branch by checking out the remote branch of this name
 
+group::
+   Group to chgrp to.
+
+mode::
+   Unix permissions, suitable for chmod.
+
+owner::
+   User to chown to.
+
 
 EXAMPLES
 --------


### PR DESCRIPTION
I was having issues with __git failing because gencode-remote was generating chmod without a mode, but I never passed a --mode parameter.

I fixed it by quoting the mode variable. I went ahead and quoted some other variables and added the optional parameters to the __git man.text.
