### PR TITLE
avoid shell differences by using printf instead of echo

### DIFF
--- a/cdist/conf/type/__key_value/gencode-remote
+++ b/cdist/conf/type/__key_value/gencode-remote
@@ -46,7 +46,8 @@ case "$state_should" in
             ;;
             wrongvalue)
                 # change exisiting value
-                echo "sed \"s|^$key\($delimiter\+\).*|$key\1$value|\" \"$file\" > \"$file.cdist-tmp\""
+                printf 'sed "s|^%s\(%s\+\).*|%s\\1%s|" "%s" > "%s.cdist-tmp"\n' \
+                    "$key" "$delimiter" "$key" "$value" "$file" "$file"
                 echo "mv \"$file.cdist-tmp\" \"$file\""
             ;;
             *)


### PR DESCRIPTION
fixes #191

see http://shebang.brandonmintern.com/bourne-is-not-bash-or-read-echo-and-backslash/

Signed-off-by: Steven Armstrong steven@icarus.ethz.ch
