### PR TITLE
__ssh_authorized_keys resets owner and permissions of the ~/.ssh/authorized_keys file when removing an existing/updated entry

### DIFF
--- a/cdist/conf/type/__ssh_authorized_keys/gencode-remote
+++ b/cdist/conf/type/__ssh_authorized_keys/gencode-remote
@@ -47,7 +47,7 @@ remove_entry() {
    prefix="#cdist:$__object_name"
    suffix="#/cdist:$__object_name"
    cat << DONE
-tmpfile=\$(mktemp)
+tmpfile=\$(mktemp ${file}.cdist.XXXXXXXXXX)
 # preserve ownership and permissions by copying existing file over tmpfile
 cp -p "$file" "\$tmpfile"
 awk -v prefix="$prefix" -v suffix="$suffix" '


### PR DESCRIPTION
so you end up with e.g.
# ls -lh ~rails/.ssh/authorized_keys
-rw------- 1 root root 6.1K Sep 27 14:46 /home/rails/.ssh/authorized_keys

instead of
# ls -lh ~rails/.ssh/authorized_keys
-rw------- 1 rails rails-group 6.1K Sep 27 14:46 /home/rails/.ssh/authorized_keys
