### PR TITLE
__key_value removes quotes from values

### DIFF
--- a/cdist/conf/type/__key_value/gencode-remote
+++ b/cdist/conf/type/__key_value/gencode-remote
@@ -26,8 +26,8 @@ state_should=present
 
 file="$(cat "$__object/parameter/file")"
 delimiter="$(cat "$__object/parameter/delimiter")"
-value="$(cat "$__object/parameter/value")"
-
+# escape double quotes, as that is what we use ourself below
+value_escaped="$(cat "$__object/parameter/value" | sed -e "s/\([\"]\)/\\\\\1/g")"
 state_is="$(cat "$__object/explorer/state")"
 
 [ "$state_is" = "$state_should" ] && exit 0
@@ -35,20 +35,29 @@ state_is="$(cat "$__object/explorer/state")"
 case "$state_should" in
     absent)
         # remove lines starting with key
-        echo "sed '/^$key\($delimiter\+\)/d' \"$file\" > \"$file.cdist-tmp\""
-        echo "mv \"$file.cdist-tmp\" \"$file\""
+        cat << DONE
+tmpfile=\$(mktemp ${file}.cdist.XXXXXXXXXX)
+# preserve ownership and permissions by copying existing file over tmpfile
+cp -p "$file" "\$tmpfile"
+sed '/^$key\($delimiter\+\)/d' "$file" > "\$tmpfile"
+mv -f "\$tmpfile" "$file"
+DONE
     ;;
     present)
         case "$state_is" in
             absent)
                 # add new key and value
-                echo "echo \"${key}${delimiter}${value}\" >> \"$file\""
+                printf 'echo "%s%s%s" >> "%s"' "$key" "$delimiter" "$value_escaped" "$file"
             ;;
             wrongvalue)
                 # change exisiting value
-                printf 'sed "s|^%s\(%s\+\).*|%s\\1%s|" "%s" > "%s.cdist-tmp"\n' \
-                    "$key" "$delimiter" "$key" "$value" "$file" "$file"
-                echo "mv \"$file.cdist-tmp\" \"$file\""
+                cat << DONE
+tmpfile=\$(mktemp ${file}.cdist.XXXXXXXXXX)
+# preserve ownership and permissions by copying existing file over tmpfile
+cp -p "$file" "\$tmpfile"
+sed "s|^$key\($delimiter\+\).*|$key\\1$value_escaped|" "$file" > "\$tmpfile"
+mv -f "\$tmpfile" "$file"
+DONE
             ;;
             *)
                 echo "Unknown explorer state: $state_is" >&2
@@ -58,4 +67,4 @@ case "$state_should" in
     *)
        echo "Unknown state: $state_should" >&2
        exit 1
-esac 
+esac


### PR DESCRIPTION
e.g. this

$ cat | cdist -v config -i - localhost << DONE
__key_value GRUB_CMDLINE_LINUX --file /tmp/grub.conf --value '"nomodeset i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0"' --delimiter '='
DONE

results in:

$ cat  /tmp/grub.conf 
GRUB_CMDLINE_LINUX=nomodeset i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0

where it should be:

$ cat  /tmp/grub.conf 
GRUB_CMDLINE_LINUX="nomodeset i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0"
