### PR TITLE
__package should use default parameters for --state

### DIFF
--- a/cdist/conf/type/__package/manifest
+++ b/cdist/conf/type/__package/manifest
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# 2011 Steven Armstrong (steven-cdist at armstrong.cc)
+# 2011-2013 Steven Armstrong (steven-cdist at armstrong.cc)
 #
 # This file is part of cdist.
 #
@@ -44,10 +44,12 @@ else
    esac
 fi
 
-set -- "$@" "$__object_id"
+state="$(cat "$__object/parameter/state")"
+
+set -- "$@" "$__object_id" "--state" "$state"
 cd "$__object/parameter"
 for property in $(ls .); do
-   if [ "$property" != "type" ]; then
+   if [ "$property" != "type" -a "$property" != "state" ]; then
       set -- "$@" "--$property" "$(cat "$property")"
    fi
 done

--- a/cdist/conf/type/__package/parameter/default/state
+++ b/cdist/conf/type/__package/parameter/default/state
@@ -1,0 +1,1 @@
+present


### PR DESCRIPTION
Otherwise the following "error" is triggered:

```
# manifest
      __package wget 
      __package wget --state present
```

```
# shell
$ cdist config -v localhost
INFO: cdist: version 2.3.7-75-gf165b56
INFO: localhost: Running global explorers
INFO: localhost: Running initial manifest /tmp/tmpuo6wqa/conf/manifest/init
ERROR: cdist: Object __package/wget already exists with conflicting parameters:
/tmp/tmpuo6wqa/conf/manifest/init: {}
/tmp/tmpuo6wqa/conf/manifest/init: {'state': 'present'}
ERROR: localhost: Command failed: /bin/sh -e /tmp/tmpuo6wqa/conf/manifest/init
INFO: cdist: Total processing time for 1 host(s): 0.604379415512085
ERROR: cdist: Failed to configure the following hosts: localhost
```

IMHO this should work. __package must be changed to use the default parameters and 'state' must be handled specially, different then the other parameters.
