### PR TITLE
default values for optional_multiple parameters do not work

### DIFF
--- a/cdist/emulator.py
+++ b/cdist/emulator.py
@@ -37,6 +37,21 @@ class MissingRequiredEnvironmentVariableError(cdist.Error):
         return self.message
 
 
+class DefaultList(list):
+    """Helper class to allow default values for optional_multiple parameters.
+
+    @see https://groups.google.com/forum/#!msg/comp.lang.python/sAUvkJEDpRc/RnRymrzJVDYJ
+    """
+    def __copy__(self):
+        return []
+
+    @classmethod
+    def create(cls, initial=None):
+        if initial:
+            initial = initial.split('\n')
+        return cls(initial)
+
+
 class Emulator(object):
     def __init__(self, argv, stdin=sys.stdin.buffer, env=os.environ):
         self.argv           = argv
@@ -101,7 +116,7 @@ class Emulator(object):
         for parameter in self.cdist_type.optional_multiple_parameters:
             argument = "--" + parameter
             parser.add_argument(argument, dest=parameter, action='append', required=False,
-                default=self.cdist_type.parameter_defaults.get(parameter, None))
+                default=DefaultList.create(self.cdist_type.parameter_defaults.get(parameter, None)))
         for parameter in self.cdist_type.boolean_parameters:
             argument = "--" + parameter
             parser.add_argument(argument, dest=parameter, action='store_const', const='')


### PR DESCRIPTION
```
$ __policy-rc.d foobar --action start --action stop --deny
Traceback (most recent call last):
  ...
  File "/usr/lib/python3.3/argparse.py", line 1705, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/lib/python3.3/argparse.py", line 1737, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib/python3.3/argparse.py", line 1943, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/lib/python3.3/argparse.py", line 1883, in consume_optional
    take_action(action, args, option_string)
  File "/usr/lib/python3.3/argparse.py", line 1811, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/lib/python3.3/argparse.py", line 949, in __call__
    items.append(values)
AttributeError: 'str' object has no attribute 'append'
```
