### PR TITLE
bugfix escaping " in type __key_value for 3.0.0

### DIFF
--- a/cdist/conf/type/__key_value/gencode-remote
+++ b/cdist/conf/type/__key_value/gencode-remote
@@ -27,7 +27,7 @@ state_should=present
 file="$(cat "$__object/parameter/file")"
 delimiter="$(cat "$__object/parameter/delimiter")"
 # escape double quotes, as that is what we use ourself below
-value_escaped="$(cat "$__object/parameter/value" | sed -e "s/\([\"]\)/\\\\\1/g")"
+value_escaped="$(cat "$__object/parameter/value" | sed -e 's/\([\"]\)/\\\1/g')"
 state_is="$(cat "$__object/explorer/state")"
 
 [ "$state_is" = "$state_should" ] && exit 0


### PR DESCRIPTION
Hello nico, 
i have a file in wich we have values like "@sdba hard nofile 131200",
in 2.3.7 this was working with the --value '"@sdba hard nofile 131200"',
in 3.0.0 the remote sed was wrong escaped.

After some try around, this patch fixes so i can set values again to values with a " in it ...
