### PR TITLE
Shell selection support via ENV

### DIFF
--- a/cdist/exec/local.py
+++ b/cdist/exec/local.py
@@ -188,7 +188,7 @@ class Local(object):
         Return the output as a string.
 
         """
-        command = ["/bin/sh", "-e"]
+        command = [ os.environ.get('CDIST_LOCAL_SHELL',"/bin/sh") , "-e"]
         command.append(script)
 
         return self.run(command=command, env=env, return_output=return_output, message_prefix=message_prefix)

--- a/cdist/exec/remote.py
+++ b/cdist/exec/remote.py
@@ -113,7 +113,7 @@ class Remote(object):
 
         """
 
-        command = ["/bin/sh", "-e"]
+        command = [ os.environ.get('CDIST_REMOTE_SHELL',"/bin/sh") , "-e"]
         command.append(script)
 
         return self.run(command, env, return_output)

--- a/cdist/shell.py
+++ b/cdist/shell.py
@@ -45,10 +45,7 @@ class Shell(object):
         """Select shell to execute, if not specified by user"""
 
         if not self.shell:
-            if 'SHELL' in os.environ:
-                self.shell = os.environ['SHELL']
-            else:
-                self.shell = "/bin/sh"
+            self.shell = os.environ.get('SHELL',"/bin/sh")
 
     def _init_files_dirs(self):
         self.local.create_files_dirs()

--- a/docs/man/man1/cdist.text
+++ b/docs/man/man1/cdist.text
@@ -127,10 +127,16 @@ usage: __git --source SOURCE [--state STATE] [--branch BRANCH]
 ENVIRONMENT
 -----------
 TMPDIR, TEMP, TMP::
-   Setup the base directory for the temporary directory.
-   See http://docs.python.org/py3k/library/tempfile.html for
-   more information. This is rather useful, if the standard
-   directory used does not allow executables.
+    Setup the base directory for the temporary directory.
+    See http://docs.python.org/py3k/library/tempfile.html for
+    more information. This is rather useful, if the standard
+    directory used does not allow executables.
+
+CDIST_LOCAL_SHELL::
+    Selects shell for local script execution, defaults to /bin/sh
+
+CDIST_REMOTE_SHELL::
+    Selects shell for remote scirpt execution, defaults to /bin/sh
 
 
 EXIT STATUS


### PR DESCRIPTION
CDIST_LOCAL_SHELL for local scripts
CDIST_REMOTE_SHELL for remote scripts

This is my simple way to solve issue #232.

With this simple solution you can use /bin/bash for example as 
your user shell, but execute manifest and local scripts with /bin/dash.
