### PR TITLE
Fixed issue #229

### DIFF
--- a/cdist/conf/type/__jail/gencode-local
+++ b/cdist/conf/type/__jail/gencode-local
@@ -23,7 +23,7 @@
 #
 
 if [ -f "$__object/parameter/jaildir" ]; then
-   jaildir="$(cat "$__object/parameter/name")"
+   jaildir="$(cat "$__object/parameter/jaildir")"
 else
    jaildir="/usr/jail"
 fi

--- a/cdist/conf/type/__jail/gencode-remote
+++ b/cdist/conf/type/__jail/gencode-remote
@@ -85,7 +85,7 @@ if [ -f "$__object/parameter/onboot" ]; then
 fi
 
 if [ -f "$__object/parameter/jaildir" ]; then
-   jaildir="$(cat "$__object/parameter/name")"
+   jaildir="$(cat "$__object/parameter/jaildir")"
 else
    jaildir="/usr/jail"
 fi

--- a/cdist/conf/type/__jail/manifest
+++ b/cdist/conf/type/__jail/manifest
@@ -34,7 +34,7 @@ if [ ! "$os" = "freebsd" ]; then
 fi
 
 if [ -f "$__object/parameter/jaildir" ]; then
-   jaildir="$(cat "$__object/parameter/name")"
+   jaildir="$(cat "$__object/parameter/jaildir")"
 else
    jaildir="/usr/jail"
 fi


### PR DESCRIPTION
Was assigning jaildir=$object/parameter/name, fixed to $object/parameter/jaildir

Decided to make this fix as the transition to FreeBSD 10 (and therefore all the changes to the __jail type) may not happen as quickly as I had imagined previously.
