### PR TITLE
__process does not work with --state absent

### DIFF
--- a/cdist/conf/type/__process/gencode-remote
+++ b/cdist/conf/type/__process/gencode-remote
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # 2011-2012 Nico Schottelius (nico-cdist at schottelius.org)
+# 2014 Steven Armstrong (steven-cdist at armstrong.cc)
 #
 # This file is part of cdist.
 #
@@ -17,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
-#
 
 if [ -f "$__object/parameter/name" ]; then
     name="$(cat "$__object/parameter/name")"
@@ -25,21 +25,18 @@ else
     name="$__object_id"
 fi
 
-parameter_state="$__object/parameter/state"
-if [ -f "$_parameter_state" ]; then
-    state_should=$(cat "$__object/parameter/state")
-else
-    state_should="present"
-fi
+state_should="$(cat "$__object/parameter/state")"
 
-runs="$(cat "$__object/explorer/runs")"
-if [ "$runs" ]; then
+if [ -s "$__object/explorer/runs" ]; then
     state_is="present"
 else
     state_is="absent"
 fi
 
-[ "$state_is" = "$state_should" ] && exit 0
+if [ "$state_is" = "$state_should" ]; then
+   # nothing to do
+   exit 0
+fi
 
 case "$state_should" in
     present)

--- a/cdist/conf/type/__process/parameter/default/state
+++ b/cdist/conf/type/__process/parameter/default/state
@@ -1,0 +1,1 @@
+present


### PR DESCRIPTION
A bug in the gencode-remote turns --state absent into 'present'.
