### PR TITLE
Docfix: ssh service listen on port 22

### DIFF
--- a/cdist/conf/type/__iptables_rule/man.text
+++ b/cdist/conf/type/__iptables_rule/man.text
@@ -41,7 +41,7 @@ __iptables_rule established  --rule "-A INPUT -m state --state RELATED,ESTABLISH
 
 # Some service rules
 __iptables_rule http  --rule "-A INPUT -p tcp --dport 80 -j ACCEPT"
-__iptables_rule ssh   --rule "-A INPUT -p tcp --dport 80 -j ACCEPT"
+__iptables_rule ssh   --rule "-A INPUT -p tcp --dport 22 -j ACCEPT"
 __iptables_rule https --rule "-A INPUT -p tcp --dport 443 -j ACCEPT"
 
 # Ensure some rules are not present anymore


### PR DESCRIPTION
Hi,

There was a typo in `__iptables_rule` documentation. SSH is actually listening on port 22 by default.
