### PR TITLE
Enhancement package pkg openbsd

### DIFF
--- a/cdist/conf/type/__package_pkg_openbsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_openbsd/gencode-remote
@@ -74,8 +74,8 @@ pkg_info | grep "^${name}.*${flavor}" > /dev/null 2>&1
 
 # We didn't find the package in the list of 'installed packages', so it failed
 # This is necessary because pkg_add doesn't return properly
-if [ $? -ne 0 ]; then
-    if [ -z "${status}" ]; then
+if [ \$? -ne 0 ]; then
+    if [ -z "\${status}" ]; then
       status="Failed to add package, uncaught exception."
     fi
     echo "Error: \$status"
@@ -92,8 +92,8 @@ pkg_info | grep "^${name}.*${flavor}" > /dev/null 2>&1
 
 # We found the package in the list of 'installed packages'
 # This would indicate that pkg_delete failed, send the output of pkg_delete
-if [ $? -eq 0 ]; then
-    if [ -z "${status}" ]; then
+if [ \$? -eq 0 ]; then
+    if [ -z "\${status}" ]; then
       status="Failed to remove package, uncaught exception."
     fi
     echo "Error: \$status"


### PR DESCRIPTION
Better error handling for installing openbsd packages - if the output of `pkg_info` doesn't contain the expected output, we should exit 1. It is possible for ${status} to be populated with informational messages, e.g.: 

```
The following new rcscripts were installed: /etc/rc.d/lighttpd
See rc.d(8) for details.
```

causing cdist to cease reading the manifest any further.
