### PR TITLE
bugfix of raw_command

### DIFF
--- a/cdist/conf/type/__cron/explorer/entry
+++ b/cdist/conf/type/__cron/explorer/entry
@@ -22,4 +22,9 @@
 name="$__object_name"
 user="$(cat "$__object/parameter/user")"
 
-crontab -u $user -l 2>/dev/null | grep "# $name\$" || true
+if [ -f "$__object/parameter/raw_command" ]; then
+    command="$(cat "$__object/parameter/command")"
+    crontab -u $user -l 2>/dev/null | grep "^$command\$" || true
+else
+    crontab -u $user -l 2>/dev/null | grep "# $name\$" || true
+fi

--- a/cdist/conf/type/__cron/gencode-remote
+++ b/cdist/conf/type/__cron/gencode-remote
@@ -26,7 +26,7 @@ command="$(cat "$__object/parameter/command")"
 
 if [ -f "$__object/parameter/raw" ]; then
    raw="$(cat "$__object/parameter/raw")"
-   entry="$raw $command"
+   entry="$raw $command # $name"
 elif [ -f "$__object/parameter/raw_command" ]; then
    entry="$command"
 else
@@ -35,10 +35,9 @@ else
    day_of_month="$(cat "$__object/parameter/day_of_month" 2>/dev/null || echo "*")"
    month="$(cat "$__object/parameter/month" 2>/dev/null || echo "*")"
    day_of_week="$(cat "$__object/parameter/day_of_week" 2>/dev/null || echo "*")"
-   entry="$minute $hour $day_of_month $month $day_of_week $command"
+   entry="$minute $hour $day_of_month $month $day_of_week $command # $name"
 fi
 
-entry="$entry # $name"
 mkdir "$__object/files"
 echo "$entry" > "$__object/files/entry"
 
@@ -85,7 +84,12 @@ case "$state_should" in
         echo ") | crontab -u $user -"
     ;;
     absent)
-        echo "( crontab -u $user -l 2>/dev/null | grep -v -E \"$filter\" 2>/dev/null || true ) | \\"
-        echo "grep -v \"# $name\\$\" | crontab -u $user -"
+        if [ -f "$__object/parameter/raw_command" ]; then
+            echo "( crontab -u $user -l 2>/dev/null | grep -v -E \"$filter\" 2>/dev/null || true ) | \\"
+            echo "grep -v \"^$entry\\$\" | crontab -u $user -"
+        else
+            echo "( crontab -u $user -l 2>/dev/null | grep -v -E \"$filter\" 2>/dev/null || true ) | \\"
+            echo "grep -v \"# $name\\$\" | crontab -u $user -"
+        fi
     ;;
 esac


### PR DESCRIPTION
with raw_command, you can set env variables in crontab,
but cron don't accept env vars if the definition is
like this:
SHELL=/bin/bash # marker of something ...
so we need to make sure that raw commands are not apended by a marker
