### PR TITLE
add support for 'replication' right for PostgreSQL roles

### DIFF
--- a/cdist/conf/type/__postgres_role/gencode-remote
+++ b/cdist/conf/type/__postgres_role/gencode-remote
@@ -30,7 +30,7 @@ case "$state_should" in
             password="$(cat "$__object/parameter/password")"
         fi
         booleans=""
-        for boolean in login createdb createrole superuser; do
+        for boolean in login createdb createrole replication superuser; do
             if [ ! -f "$__object/parameter/$boolean" ]; then
                 boolean="no${boolean}"
             fi

--- a/cdist/conf/type/__postgres_role/man.text
+++ b/cdist/conf/type/__postgres_role/man.text
@@ -31,6 +31,7 @@ parameters.
 login::
 createdb::
 createrole::
+replication::
 superuser::
 inherit::
 

--- a/cdist/conf/type/__postgres_role/parameter/boolean
+++ b/cdist/conf/type/__postgres_role/parameter/boolean
@@ -1,5 +1,6 @@
 login
 createdb
 createrole
+replication
 superuser
 inherit


### PR DESCRIPTION
Since version 9.1 PostgreSQL supports the REPLICATION right: http://www.postgresql.org/docs/9.1/static/sql-createrole.html
