### PR TITLE
split cache into separate dirs per start time

### DIFF
--- a/cdist/config.py
+++ b/cdist/config.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # 2010-2013 Nico Schottelius (nico-cdist at schottelius.org)
+# 2014      Daniel Heule     (hda at sfs.biz)
 #
 # This file is part of cdist.
 #
@@ -155,7 +156,7 @@ class Config(object):
         self.manifest.run_initial_manifest(self.local.initial_manifest)
         self.iterate_until_finished()
 
-        self.local.save_cache()
+        self.local.save_cache(start_time)
         self.log.info("Finished successful run in %s seconds", time.time() - start_time)
 
 

--- a/cdist/exec/local.py
+++ b/cdist/exec/local.py
@@ -2,6 +2,7 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2011-2013 Nico Schottelius (nico-cdist at schottelius.org)
+# 2014 Daniel Heule (hda at sfs.biz)
 #
 # This file is part of cdist.
 #
@@ -28,6 +29,7 @@ import subprocess
 import shutil
 import logging
 import tempfile
+import time
 
 import cdist
 import cdist.message
@@ -193,13 +195,13 @@ class Local(object):
 
         return self.run(command=command, env=env, return_output=return_output, message_prefix=message_prefix)
 
-    def save_cache(self):
+    def save_cache(self,starttime=time.time()):
         if os.path.isabs(self.target_host):
             hostdir = self.target_host[1:]
         else:
             hostdir = self.target_host
 
-        destination = os.path.join(self.cache_path, hostdir)
+        destination = os.path.join(self.cache_path, time.strftime('%Y-%m-%d',time.localtime(starttime)), time.strftime('%H%M%S',time.localtime(starttime)), hostdir)
         self.log.debug("Saving " + self.base_path + " to " + destination)
 
         try:


### PR DESCRIPTION
I have chosen this structure to simplify the cleanup
of the old configure runs. Now the structure is:
cdist/cache/yyyy-mm-dd/HHMMSS/hostname
the time is the starttime of the configure run,
so if you configure your host serial, you have more than one
directory at the time level, if you start with -p, you have one.
