### PR TITLE
Added Mitel as a redhat derived OS

### DIFF
--- a/cdist/conf/explorer/os
+++ b/cdist/conf/explorer/os
@@ -77,6 +77,11 @@ if grep -q ^Fedora /etc/redhat-release 2>/dev/null; then
    exit 0
 fi
 
+if grep -q ^Mitel /etc/redhat-release 2>/dev/null; then
+   echo mitel
+   exit 0
+fi
+
 if [ -f /etc/redhat-release ]; then
    echo redhat
    exit 0

--- a/cdist/conf/explorer/os_version
+++ b/cdist/conf/explorer/os_version
@@ -51,7 +51,7 @@ case "$($__explorer/os)" in
    owl)
       cat /etc/owl-release
    ;;
-   redhat|centos)
+   redhat|centos|mitel)
       cat /etc/redhat-release
    ;;
    slackware)


### PR DESCRIPTION
Hi,

We have some Mitel PABX machines which are a Red Hat derivative, but use different version numbering. This extra os explorer may be helpful for others too.