### PR TITLE
bugfix for newer zypper (SLES12SP1) releases

### DIFF
--- a/cdist/conf/type/__zypper_service/explorer/service_uri
+++ b/cdist/conf/type/__zypper_service/explorer/service_uri
@@ -27,4 +27,4 @@ else
 fi
 # simpler command which works only on SLES11 SP3 or newer:
 # echo $(zypper ls -u -E | grep -E "\<$uri\>" | cut -d'|' -f 7)
-echo $(zypper ls -u | grep -E '^([^|]+\|){3,3} Yes' | grep -E "\<$uri\>" | cut -d'|' -f 7 )
+echo $(zypper ls -u | grep -E '^([^|]+\|){3,3} Yes' | grep -E "\<$uri\>" | awk '{print $NF}')

--- a/cdist/conf/type/__zypper_service/explorer/service_uri
+++ b/cdist/conf/type/__zypper_service/explorer/service_uri
@@ -25,6 +25,4 @@ if [ -f "$__object/parameter/uri" ]; then
 else
    uri="/$__object_id"
 fi
-# simpler command which works only on SLES11 SP3 or newer:
-# echo $(zypper ls -u -E | grep -E "\<$uri\>" | cut -d'|' -f 7)
-echo $(zypper ls -u | grep -E '^([^|]+\|){3,3} Yes' | grep -E "\<$uri\>" | awk '{print $NF}')
+echo $(zypper ls -u | awk 'BEGIN { FS = "[ ]+\\|[ ]+" } ; $4 == "Yes" && $NF == "'$uri'" {print $NF}')


### PR DESCRIPTION
zypper uses now more fields in output of service list, but url is allways the last one