### PR TITLE
fix for __start_on_boot for ALL systemd distros

### DIFF
--- a/cdist/conf/explorer/init
+++ b/cdist/conf/explorer/init
@@ -27,10 +27,8 @@ uname_s="$(uname -s)"
 case "$uname_s" in
     Linux|FreeBSD)
         ps -o comm= -p 1 || true
-        exit 0
     ;;
     *)
-        echo "init exlorer needs to be implemented for $os" >&2
-        exit 1
+        echo "unknown"
     ;;
 esac

--- a/cdist/conf/explorer/init
+++ b/cdist/conf/explorer/init
@@ -18,7 +18,19 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 #
-# Check whether the given name will be started on boot or not
+# Returns the process name of pid 1 ( normaly the init system )
+# for example at linux this value is "init" or "systemd" in most cases
 #
 
-ps -o comm= --pid 1
+uname_s="$(uname -s)"
+
+case "$uname_s" in
+    Linux|FreeBSD)
+        ps -o comm= -p 1 || true
+        exit 0
+    ;;
+    *)
+        echo "init exlorer needs to be implemented for $os" >&2
+        exit 1
+    ;;
+esac

--- a/cdist/conf/explorer/init
+++ b/cdist/conf/explorer/init
@@ -29,6 +29,7 @@ case "$uname_s" in
         ps -o comm= -p 1 || true
     ;;
     *)
-        echo "unknown"
+        # return a empty string as unknown value
+        echo ""
     ;;
 esac

--- a/cdist/conf/explorer/init
+++ b/cdist/conf/explorer/init
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# 2016 Daniel Heule (hda at sfs.biz)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+# Check whether the given name will be started on boot or not
+#
+
+ps -o comm= --pid 1

--- a/cdist/conf/type/__start_on_boot/explorer/state
+++ b/cdist/conf/type/__start_on_boot/explorer/state
@@ -24,47 +24,51 @@
 
 os=$("$__explorer/os")
 runlevel=$("$__explorer/runlevel")
+init=$("$__explorer/init")
 target_runlevel="$(cat "$__object/parameter/target_runlevel")"
 name="$__object_id"
 
-case "$os" in
-    archlinux)
-        state=$(systemctl is-enabled "$name" >/dev/null 2>&1 \
-            && echo present \
-            || echo absent)
-    ;;
+if [ "$init" == 'systemd' ]; then
+    # this handles ALL linux distros with systemd
+    # e.g. archlinux, gentoo, new RHEL and SLES versions
+    state=$(systemctl is-enabled "$name" >/dev/null 2>&1 \
+        && echo present \
+        || echo absent)
 
-    debian|openwrt)
-        state="present"
-        [ -f "/etc/rc$runlevel.d/S"??"$name" ] || state="absent"
-    ;;
-    ubuntu)
-        state="absent"
-        [ -f "/etc/rc$runlevel.d/S"??"$name" ] && state="present"
-        [ -f "/etc/init/${name}.conf" ] && state="present"
-    ;;
+else
+    case "$os" in
+        debian|openwrt)
+            state="present"
+            [ -f "/etc/rc$runlevel.d/S"??"$name" ] || state="absent"
+        ;;
+        ubuntu)
+            state="absent"
+            [ -f "/etc/rc$runlevel.d/S"??"$name" ] && state="present"
+            [ -f "/etc/init/${name}.conf" ] && state="present"
+        ;;
 
-    amazon|centos|fedora|owl|redhat)
-        state=$(chkconfig --level "$runlevel" "$name" || echo absent)
-        [ "$state" ] || state="present"
-    ;;
-    suse)
-        # check for target if set, usable for boot. services in runlevel B
-        if [ "$target_runlevel" != 'default' ]; then
-            runlevel="$target_runlevel"
-        fi
-        # suses chkconfig has the same name, but works different ...
-        state=$(chkconfig --check "$name" "$runlevel" || echo absent)
-        [ "$state" ] || state="present"
-    ;;
-    gentoo)
-        state="present"
-        [ -f "/etc/runlevels/${target_runlevel}/${name}" ] || state="absent"
-    ;;
-    *)
-       echo "Unsupported os: $os" >&2
-       exit 1
-    ;;
-esac
+        amazon|centos|fedora|owl|redhat)
+            state=$(chkconfig --level "$runlevel" "$name" || echo absent)
+            [ "$state" ] || state="present"
+        ;;
+        suse)
+            # check for target if set, usable for boot. services in runlevel B
+            if [ "$target_runlevel" != 'default' ]; then
+                runlevel="$target_runlevel"
+            fi
+            # suses chkconfig has the same name, but works different ...
+            state=$(chkconfig --check "$name" "$runlevel" || echo absent)
+            [ "$state" ] || state="present"
+        ;;
+        gentoo)
+            state="present"
+            [ -f "/etc/runlevels/${target_runlevel}/${name}" ] || state="absent"
+        ;;
+        *)
+           echo "Unsupported os: $os" >&2
+           exit 1
+        ;;
+    esac
+fi
 
 echo $state

--- a/cdist/conf/type/__start_on_boot/gencode-remote
+++ b/cdist/conf/type/__start_on_boot/gencode-remote
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # 2012-2013 Nico Schottelius (nico-cdist at schottelius.org)
-# 2013 Daniel Heule (hda at sfs.biz)
+# 2016 Daniel Heule (hda at sfs.biz)
 #
 # This file is part of cdist.
 #
@@ -22,6 +22,7 @@
 
 state_should="$(cat "$__object/parameter/state")"
 state_is=$(cat "$__object/explorer/state")
+init=$(cat "$__global/explorer/init")
 target_runlevel="$(cat "$__object/parameter/target_runlevel")"
 
 # Short circuit if nothing is to be done
@@ -33,78 +34,86 @@ name="$__object_id"
 
 case "$state_should" in
     present)
-        case "$os" in
-            archlinux)
-                echo "systemctl enable \"$name\""
-            ;;
-            debian)
-                case "$os_version" in
-                    [1-7]*)
-                        echo "update-rc.d \"$name\" defaults >/dev/null"
-                    ;;
-                    8*)
-                        echo "systemctl enable \"$name\""
-                    ;;
-                    *)
-                        echo "Unsupported version $os_version of $os" >&2
-                        exit 1
-                    ;;
-                esac
-            ;;
+        if [ "$init" == 'systemd' ]; then
+            # this handles ALL linux distros with systemd
+            # e.g. archlinux, gentoo in some cases, new RHEL and SLES versions
+            echo "systemctl -q enable \"$name\""
+        else
+            case "$os" in
+                debian)
+                    case "$os_version" in
+                        [1-7]*)
+                            echo "update-rc.d \"$name\" defaults >/dev/null"
+                        ;;
+                        8*)
+                            echo "systemctl enable \"$name\""
+                        ;;
+                        *)
+                            echo "Unsupported version $os_version of $os" >&2
+                            exit 1
+                        ;;
+                    esac
+                ;;
 
-            gentoo)
-                echo rc-update add \"$name\" \"$target_runlevel\"
-            ;;
+                gentoo)
+                    echo rc-update add \"$name\" \"$target_runlevel\"
+                ;;
 
-            amazon|centos|fedora|owl|redhat|suse)
-                echo chkconfig \"$name\" on
-            ;;
+                amazon|centos|fedora|owl|redhat|suse)
+                    echo chkconfig \"$name\" on
+                            echo "Unsupported version $os_version of $os" >&2
+                            exit 1
+                ;;
 
-            openwrt)
-                # 'enable' can be successful and still return a non-zero exit
-                # code, deal with it by checking for success ourselves in that
-                # case (the || ... part).
-                echo "/etc/init.d/\"$name\" enable || [ -f /etc/rc.d/S??\"$name\" ]"
-            ;;
+                openwrt)
+                    # 'enable' can be successful and still return a non-zero exit
+                    # code, deal with it by checking for success ourselves in that
+                    # case (the || ... part).
+                    echo "/etc/init.d/\"$name\" enable || [ -f /etc/rc.d/S??\"$name\" ]"
+                ;;
 
-            ubuntu)
-                echo "update-rc.d \"$name\" defaults >/dev/null"
-            ;;
+                ubuntu)
+                    echo "update-rc.d \"$name\" defaults >/dev/null"
+                ;;
 
-            *)
-               echo "Unsupported os: $os" >&2
-               exit 1
-            ;;
-        esac
+                *)
+                   echo "Unsupported os: $os" >&2
+                   exit 1
+                ;;
+            esac
+        fi
     ;;
 
     absent)
-        case "$os" in
-            archlinux)
-                echo "systemctl disable \"$name\""
-            ;;
-            debian|ubuntu)
-                echo update-rc.d -f \"$name\" remove
-            ;;
+        if [ "$init" == 'systemd' ]; then
+            # this handles ALL linux distros with systemd
+            # e.g. archlinux, gentoo in some cases, new RHEL and SLES versions
+            echo "systemctl -q disable \"$name\""
 
-            gentoo)
-                echo rc-update del \"$name\"  \"$target_runlevel\"
-            ;;
+        else
+            case "$os" in
+                debian|ubuntu)
+                    echo update-rc.d -f \"$name\" remove
+                ;;
 
-            centos|fedora|owl|redhat|suse)
-                echo chkconfig \"$name\" off
-            ;;
+                gentoo)
+                    echo rc-update del \"$name\"  \"$target_runlevel\"
+                ;;
 
-            openwrt)
-                echo "\"/etc/init.d/$name\" disable"
-            ;;
+                centos|fedora|owl|redhat|suse)
+                    echo chkconfig \"$name\" off
+                ;;
 
-            *)
-               echo "Unsupported os: $os" >&2
-               exit 1
-            ;;
-        esac
- 
+                openwrt)
+                    echo "\"/etc/init.d/$name\" disable"
+                ;;
+
+                *)
+                   echo "Unsupported os: $os" >&2
+                   exit 1
+                ;;
+            esac
+        fi
     ;;
 
     *)


### PR DESCRIPTION
- a new global explorer "init" which retrives the command name of pid 1 (init OR systemd)
- fix __start_on_boot so ALL systemd distros get handled correct out of the box
