### PR TITLE
Fix remote exec bug and bug with save_cache and ssh mux socket file.

### DIFF
--- a/cdist/exec/remote.py
+++ b/cdist/exec/remote.py
@@ -146,10 +146,9 @@ class Remote(object):
         # remotely in e.g. csh and setting up CDIST_REMOTE_SHELL to e.g.
         # /bin/csh will execute this script in the right way.
         if env:
-            cmd.append("/bin/sh")
-            cmd.append("-c")
             remote_env = [" export %s=%s;" % item for item in env.items()]
-            string_cmd = " ".join(remote_env) + " ".join(command)
+            string_cmd = ("/bin/sh -c '" + " ".join(remote_env)
+                + " ".join(command) + "'")
             cmd.append(string_cmd)
         else:
             cmd.extend(command)

--- a/cdist/test/exec/remote.py
+++ b/cdist/test/exec/remote.py
@@ -155,9 +155,16 @@ class RemoteTestCase(test.CdistTestCase):
         r = remote.Remote(self.target_host, base_path=self.base_path, remote_exec=remote_exec, remote_copy=remote_copy)
         output = r.run_script(script, return_output=True)
         self.assertEqual(output, "no_env\n")
+
+        handle, remote_exec_path = self.mkstemp(dir=self.temp_dir)
+        with os.fdopen(handle, 'w') as fd:
+            fd.writelines(["#!/bin/sh\n", 'shift; cmd=$1; eval $cmd\n'])
+        os.chmod(remote_exec_path, 0o755)
+        remote_exec = remote_exec_path
         env = {
             '__object': 'test_object',
         }
+        r = remote.Remote(self.target_host, base_path=self.base_path, remote_exec=remote_exec, remote_copy=remote_copy)
         output = r.run_script(script, env=env, return_output=True)
         self.assertEqual(output, "test_object\n")
 

--- a/scripts/cdist
+++ b/scripts/cdist
@@ -26,7 +26,8 @@ def inspect_ssh_mux_opts(control_path_dir="~/.ssh/"):
     import subprocess
     import os
 
-    control_path = os.path.join(control_path_dir, "cdist.master-%l-%r@%h:%p")
+    control_path = os.path.join(control_path_dir,
+            "cdist.socket.master-%l-%r@%h:%p")
     wanted_mux_opts = {
         "ControlPath": control_path,
         "ControlMaster": "auto",
@@ -133,24 +134,13 @@ def commandline():
     args_dict = vars(args)
     # if command with remote_copy and remote_exec params
     if 'remote_copy' in args_dict and 'remote_exec' in args_dict:
-        # if out_path is not set then create temp dir here so
-        # Local uses it for base_path and ssh mux socket is
-        # created in it.
-        if args_dict['out_path'] is None:
-            args.out_path = tempfile.mkdtemp()
-            is_temp_dir = True
-        else:
-            is_temp_dir = False
         # if remote-exec and/or remote-copy args are None then user
         # didn't specify command line options nor env vars:
         # inspect multiplexing options for default cdist.REMOTE_COPY/EXEC
         if args_dict['remote_copy'] is None or args_dict['remote_exec'] is None:
-            control_path_dir = args.out_path
-            # only rmtree if it is temp directory;
-            # if user specifies out_path do not remove it
-            if is_temp_dir:
-                import atexit
-                atexit.register(lambda: shutil.rmtree(control_path_dir))
+            control_path_dir = tempfile.mkdtemp()
+            import atexit
+            atexit.register(lambda: shutil.rmtree(control_path_dir))
             mux_opts = inspect_ssh_mux_opts(control_path_dir)
             if args_dict['remote_exec'] is None:
                 args.remote_exec = cdist.REMOTE_EXEC + mux_opts


### PR DESCRIPTION
There is a problem with recent mux options for cdist default ssh/scp usage. ControlPath master socket is created in the temp directory cdist uses for storing files. And this temp dir is in the end saved to cache. But it is an error to move socket file. So I fixed this by changing shutil.move with shutil.copytree, with ignore socket filename pattern, and shutil.rmtree. It is known that Local base_path is a directory and also that destination is a directory. In newer python versions shutil.move also has copy_function parameter but 3.2 don't.
There also is a bug in Remote exec command. I made changes so that cdist does not depend on remote default root shell being posix shell. With this change it can be e.g. csh. But until now when I got ungleich VM for developing rocketchat type I didn't have a real world machine to test with and unit test didn't show this bug.
Without this fix cdist won't work.
