### PR TITLE
Make build-helper for my FreeBSD.

### DIFF
--- a/bin/build-helper.darko
+++ b/bin/build-helper.darko
@@ -1,0 +1,336 @@
+#!/bin/sh
+#
+# 2011-2013 Nico Schottelius (nico-cdist at schottelius.org)
+# 2016 Darko Poljak (darko.poljak at gmail.com)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+# This file contains the heavy lifting found usually in the Makefile
+#
+
+# vars for make
+helper=$0
+
+basedir=${0%/*}/../
+# run_as is used to check how the script is called (by $0 value)
+# currently supported sufixes for $0 are:
+# .darko - run as darko
+basename=${0##*/}
+run_as=${basename#*.}
+case "$run_as" in
+    darko)
+        to_a=cdist-configuration-management
+        to_d=googlegroups.com
+        from_a=darko.poljak
+        from_d=gmail.com
+        ml_name="Darko Poljak"
+        ml_sig_name="Darko"
+
+        # vars for make
+        WEBDIR=../vcs/www.nico.schottelius.org
+    ;;
+    *)
+        to_a=cdist
+        to_d=l.schottelius.org
+        from_a=nico-cdist
+        from_d=schottelius.org
+        ml_name="Nico -telmich- Schottelius"
+        ml_sig_name="Nico"
+
+        # vars for make
+        WEBDIR=$$HOME/vcs/www.nico.schottelius.org
+    ;;
+esac
+
+# Change to checkout directory
+cd "$basedir"
+
+version=$(git describe)
+
+option=$1; shift
+
+case "$option" in
+    print-make-vars)
+        printf "helper: ${helper}\n"
+        printf "WEBDIR: ${WEBDIR}\n"
+    ;;
+    print-runas)
+        printf "run_as: $run_as\n"
+    ;;
+    changelog-changes)
+        if [ "$#" -eq 1 ]; then
+            start=$1
+        else
+            start="[[:digit:]]"
+        fi
+
+        end="[[:digit:]]"
+
+        awk -F: "BEGIN { start=0 }
+            {
+                if(start == 0) {
+                    if (\$0 ~ /^$start/) {
+                        start = 1
+                    }
+                } else {
+                    if (\$0 ~ /^$end/) {
+                        exit
+                    } else {
+                        print \$0 
+                    }
+                }
+            }" "$basedir/docs/changelog"
+    ;;
+
+    changelog-version)
+        # get version from changelog
+        grep '^[[:digit:]]' "$basedir/docs/changelog" | head -n1 | sed 's/:.*//'
+    ;;
+
+    check-date)
+        # verify date in changelog is today
+        date_today="$(date +%Y-%m-%d)"
+        date_changelog=$(grep '^[[:digit:]]' "$basedir/docs/changelog" | head -n1 | sed 's/.*: //')
+
+        if [ "$date_today" != "$date_changelog" ]; then
+            echo "Date in changelog is not today"
+            echo "Changelog: $date_changelog"
+            exit 1
+        fi
+    ;;
+
+    check-unittest)
+        "$0" test
+    ;;
+
+    blog)
+        version=$1; shift
+        blogfile=$1; shift
+        dir=${blogfile%/*}
+        file=${blogfile##*/}
+
+
+        cat << eof > "$blogfile"
+[[!meta title="Cdist $version released"]]
+
+Here's a short overview about the changes found in version ${version}:
+
+eof
+
+        $0 changelog-changes "$version" >> "$blogfile"
+
+        cat << eof >> "$blogfile"
+For more information visit the [[cdist homepage|software/cdist]].
+
+[[!tag cdist config unix]]
+eof
+        cd "$dir"
+        git add "$file"
+        # Allow git commit to fail if there are no changes
+        git commit -m "cdist blog update: $version" "$blogfile" || true
+    ;;
+
+    ml-release)
+        if [ $# -ne 1 ]; then
+            echo "$0 ml-release version" >&2
+            exit 1
+        fi
+
+        version=$1; shift
+
+        to=${to_a}@${to_d}
+        from=${from_a}@${from_d}
+
+        ( 
+        cat << eof
+From: ${ml_name} <$from>
+To: cdist mailing list <$to>
+Subject: cdist $version released
+
+Hello .*,
+
+cdist $version has been released with the following changes:
+
+eof
+
+        "$0" changelog-changes "$version"
+        cat << eof
+
+Cheers,
+
+${ml_sig_name}
+
+-- 
+Automatisation at its best level. With cdist.
+eof
+        ) | /usr/sbin/sendmail -f "$from" "$to"
+    ;;
+
+    release-git-tag)
+        target_version=$($0 changelog-version)
+        if git rev-parse --verify refs/tags/$target_version 2>/dev/null; then
+            echo "Tag for $target_version exists, aborting"
+            exit 1
+        fi
+        printf "Enter tag description for ${target_version}: "
+        read tagmessage
+        git tag "$target_version" -m "$$tagmessage"
+    ;;
+
+    release)
+        set -e
+        target_version=$($0 changelog-version)
+        target_branch=$($0 version-branch)
+
+        echo "Beginning release process for $target_version"
+
+        # First check everything is sane
+        "$0" check-date
+        "$0" check-unittest
+
+        # Generate version file to be included in packaging
+        "$0" version
+
+        # Ensure the git status is clean, else abort
+        if ! git diff-index --name-only --exit-code HEAD ; then
+            echo "Unclean tree, see files above, aborting"
+            exit 1
+        fi
+
+        # Ensure we are on the master branch
+        masterbranch=yes
+        if [ "$(git rev-parse --abbrev-ref HEAD)" != "master" ]; then
+            echo "Releases are happening from the master branch, aborting"
+
+            echo "Enter the magic word to release anyway"
+            read magicword
+
+            if [ "$magicword" = "iknowwhatido" ]; then
+                masterbranch=no
+            else
+                exit 1
+            fi
+        fi
+
+        if [ "$masterbranch" = yes ]; then
+            # Ensure version branch exists
+            if ! git rev-parse --verify refs/heads/$target_branch 2>/dev/null; then
+                git branch "$target_branch"
+            fi
+
+            # Merge master branch into version branch
+            git checkout "$target_branch"
+            git merge master
+        fi
+
+        # Verify that after the merge everything works
+        "$0" check-date
+        "$0" check-unittest
+
+        # Generate man pages (indirect check if they build)
+        make helper=${helper} WEBDIR=${WEBDIR} man
+
+        # Generate speeches (indirect check if they build)
+        make helper=${helper} WEBDIR=${WEBDIR} speeches
+
+        ############################################################# 
+        # Everything green, let's do the release
+
+        # Tag the current commit
+        "$0" release-git-tag
+
+        # Also merge back the version branch
+        if [ "$masterbranch" = yes ]; then
+            git checkout master
+            git merge "$target_branch"
+        fi
+
+        # Publish git changes
+        make helper=${helper} WEBDIR=${WEBDIR} pub
+
+        # publish man, speeches, website
+        if [ "$masterbranch" = yes ]; then
+            make helper=${helper} WEBDIR=${WEBDIR} web-release-all
+        else
+            make helper=${helper} WEBDIR=${WEBDIR} web-release-all-no-latest
+        fi
+
+        # Ensure that pypi release has the right version
+        "$0" version
+
+        # Create and publish package for pypi
+        make helper=${helper} WEBDIR=${WEBDIR} pypi-release
+
+        case "$run_as" in
+            darko)
+            ;;
+            *)
+                # Archlinux release is based on pypi
+                make archlinux-release
+            ;;
+        esac
+
+        # Announce change on ML
+        make helper=${helper} WEBDIR=${WEBDIR} ml-release
+
+        cat << eof
+Manual steps post release:
+
+    - linkedin
+    - hackernews
+    - reddit
+    - twitter
+
+eof
+
+        case "$run_as" in
+            darko)
+                cat <<eof
+Additional steps post release:
+    - archlinux release
+eof
+            ;;
+            *)
+            ;;
+        esac
+
+    ;;
+
+    test)
+        export PYTHONPATH="$(pwd -P)"
+
+        if [ $# -lt 1 ]; then
+            python3 -m cdist.test
+        else
+            python3 -m unittest "$@"
+        fi
+    ;;
+
+    version-branch)
+        "$0" changelog-version | cut -d. -f '1,2'
+    ;;
+
+    version)
+        echo "VERSION = \"$(git describe)\"" > cdist/version.py
+    ;;
+
+    *)
+        echo "Unknown helper target $@ - aborting"
+        exit 1
+    ;;
+
+esac


### PR DESCRIPTION
Hi!

I have made this build-helper variant.
I used it to build 4.0.0.
It is original build-helper changed to work on FreeBSD and for me and my laptop settings.

Please review it.
Should it be added to ungleich/cdist as is, as new file
or should I make it be build-helper and then 
ln -s build-helper build-helper.darko.

What do you think?

Perhaps it should be named with freebsd suffix and changed accordingly.

I am also thinking about adding some README file or comment inside script with info what need to be setup before running build and what needs to be done afterwards, what to check and what to do manually.