### PR TITLE
Option -f: read additional hosts from file (stdin)

### DIFF
--- a/cdist/conf/type/__block/man.text
+++ b/cdist/conf/type/__block/man.text
@@ -34,7 +34,7 @@ prefix::
    Defaults to #cdist:__block/$__object_id
 
 suffix::
-   the prefix to add after the text.
+   the suffix to add after the text.
    Defaults to #/cdist:__block/$__object_id
 
 state::

--- a/docs/changelog
+++ b/docs/changelog
@@ -1,6 +1,9 @@
 Changelog
 ---------
 
+next:
+	* Core: Add -f option to read additional hosts from file/stdin (Darko Poljak)
+
 4.0.0: 2016-05-04
 	* Core: Fix bug with parallel hosts operation when output path is specifed (Darko Poljak)
 	* Type __package_pip: Add support for running as specified user (useful for pip in venv) (Darko Poljak)
@@ -24,7 +27,6 @@ Changelog
 	* Type __group: Add NetBSD support (Jonathan A. Kollasch)
 	* Type __consul: Add new consul versions (Nico Schottelius)
 	* Type __apt_ppa: Do not install legacy package python-software-properties (Steven Armstrong)
-
 
 3.1.13: 2015-05-16
 	* Type __block: Fix support for non stdin blocks (Dominique Roux)

--- a/docs/man/man1/cdist.text
+++ b/docs/man/man1/cdist.text
@@ -14,7 +14,7 @@ cdist [-h] [-d] [-v] [-V] {banner,config,shell} ...
 
 cdist banner [-h] [-d] [-v]
 
-cdist config [-h] [-d] [-V] [-c CONF_DIR] [-i MANIFEST] [-p] [-s] host [host ...]
+cdist config [-h] [-d] [-V] [-c CONF_DIR] [-f HOSTFILE] [-i MANIFEST] [-p] [-s] [host [host ...]]
 
 cdist shell [-h] [-d] [-v] [-s SHELL]
 
@@ -63,6 +63,11 @@ Configure one or more hosts
     --conf-dir argument have higher precedence over those set through the
     environment variable.
 
+-f HOSTFILE, --file HOSTFILE::
+    Read hosts to operate on from specified file or from stdin if '-'
+    (each host on separate line). If no host or host file is
+    specified then, by default, read hosts from stdin.
+
 -i MANIFEST, --initial-manifest MANIFEST::
     Path to a cdist manifest or - to read from stdin
 
@@ -104,6 +109,9 @@ EXAMPLES
 % cdist config --remote-exec /path/to/my/remote/exec \
     --remote-copy /path/to/my/remote/copy \
     -p ikq02.ethz.ch ikq03.ethz.ch ikq04.ethz.ch
+
+# Configure hosts in parallel by reading hosts from file loadbalancers
+% cdist config -f loadbalancers
 
 # Display banner
 cdist banner

--- a/docs/man/man1/cdist.text
+++ b/docs/man/man1/cdist.text
@@ -64,9 +64,10 @@ Configure one or more hosts
     environment variable.
 
 -f HOSTFILE, --file HOSTFILE::
-    Read hosts to operate on from specified file or from stdin if '-'
-    (each host on separate line). If no host or host file is
-    specified then, by default, read hosts from stdin.
+    Read additional hosts to operate on from specified file
+    or from stdin if '-' (each host on separate line).
+    If no host or host file is specified then, by default,
+    read hosts from stdin.
 
 -i MANIFEST, --initial-manifest MANIFEST::
     Path to a cdist manifest or - to read from stdin

--- a/docs/man/man1/cdist.text
+++ b/docs/man/man1/cdist.text
@@ -111,7 +111,7 @@ EXAMPLES
     --remote-copy /path/to/my/remote/copy \
     -p ikq02.ethz.ch ikq03.ethz.ch ikq04.ethz.ch
 
-# Configure hosts in parallel by reading hosts from file loadbalancers
+# Configure hosts read from file loadbalancers
 % cdist config -f loadbalancers
 
 # Display banner

--- a/scripts/cdist
+++ b/scripts/cdist
@@ -90,9 +90,10 @@ def commandline():
          help=('Add configuration directory (can be repeated, '
              'last one wins)'), action='append')
     parser['config'].add_argument('-f', '--file',
-         help=('Read hosts to operate on from specified file or from stdin '
-             'if \'-\' (each host on separate line). If no host or host '
-             'file is specified then, by default, read hosts from stdin.'),
+         help=('Read additional hosts to operate on from specified file '
+             'or from stdin if \'-\' (each host on separate line). '
+             'If no host or host file is specified then, by default, '
+             'read hosts from stdin.'),
          dest='hostfile', required=False)
     parser['config'].add_argument('-i', '--initial-manifest', 
          help='Path to a cdist manifest or \'-\' to read from stdin.',

--- a/scripts/cdist
+++ b/scripts/cdist
@@ -85,7 +85,7 @@ def commandline():
     parser['config'] = parser['sub'].add_parser('config',
         parents=[parser['loglevel']])
     parser['config'].add_argument('host', nargs='*',
-        help='one or more hosts to operate on')
+        help='host(s) to operate on')
     parser['config'].add_argument('-c', '--conf-dir',
          help=('Add configuration directory (can be repeated, '
              'last one wins)'), action='append')

--- a/scripts/cdist
+++ b/scripts/cdist
@@ -67,12 +67,14 @@ def commandline():
         action='store_true', default=False)
 
     # Main subcommand parser
-    parser['main'] = argparse.ArgumentParser(description='cdist ' + cdist.VERSION,
+    parser['main'] = argparse.ArgumentParser(description='cdist '
+            + cdist.VERSION,
         parents=[parser['loglevel']])
     parser['main'].add_argument('-V', '--version',
         help='Show version', action='version',
         version='%(prog)s ' + cdist.VERSION)
-    parser['sub'] = parser['main'].add_subparsers(title="Commands")
+    parser['sub'] = parser['main'].add_subparsers(title="Commands",
+            dest="command")
 
     # Banner
     parser['banner'] = parser['sub'].add_parser('banner', 
@@ -82,11 +84,16 @@ def commandline():
     # Config
     parser['config'] = parser['sub'].add_parser('config',
         parents=[parser['loglevel']])
-    parser['config'].add_argument('host', nargs='+',
+    parser['config'].add_argument('host', nargs='*',
         help='one or more hosts to operate on')
     parser['config'].add_argument('-c', '--conf-dir',
-         help='Add configuration directory (can be repeated, last one wins)',
-         action='append')
+         help=('Add configuration directory (can be repeated, '
+             'last one wins)'), action='append')
+    parser['config'].add_argument('-f', '--file',
+         help=('Read hosts to operate on from specified file or from stdin '
+             'if \'-\' (each host on separate line). If no host or host '
+             'file is specified then, by default, read hosts from stdin.'),
+         dest='hostfile', required=False)
     parser['config'].add_argument('-i', '--initial-manifest', 
          help='Path to a cdist manifest or \'-\' to read from stdin.',
          dest='manifest', required=False)
@@ -108,7 +115,8 @@ def commandline():
          action='store', dest='remote_copy',
          default=os.environ.get('CDIST_REMOTE_COPY'))
     parser['config'].add_argument('--remote-exec',
-         help='Command to use for remote execution (should behave like ssh)',
+         help=('Command to use for remote execution '
+               '(should behave like ssh)'),
          action='store', dest='remote_exec',
          default=os.environ.get('CDIST_REMOTE_EXEC'))
     parser['config'].set_defaults(func=cdist.config.Config.commandline)
@@ -146,6 +154,11 @@ def commandline():
                 args.remote_exec = cdist.REMOTE_EXEC + mux_opts
             if args_dict['remote_copy'] is None:
                 args.remote_copy = cdist.REMOTE_COPY + mux_opts
+
+    if args.command == 'config':
+        if args.manifest == '-' and args.hostfile == '-':
+            print('cdist config: error: cannot read both, manifest and host file, from stdin')
+            sys.exit(1)
 
     log.debug(args)
     log.info("version %s" % cdist.VERSION)


### PR DESCRIPTION
Hello!

I added -f option to read additional hosts from file or stdin if -f argument is '-'. With this change cdist gets hosts from both, command line arguments and file specified with -f. You can specify both, one of them or none. In case you don't specify hosts on command line or with -f option, cdist reads hosts file from stdin by default. Note that it is an error specifying both initial manifest and host file as '-'.

This is helpful when you need to configure many hosts, e.g. more than 10.
Now you don't need to specify them all at command line, you can have list of them in separate file, each host on its line.