### PR TITLE
Bugfix: ssh mux controlpath too long on some envs.

### DIFF
--- a/scripts/cdist
+++ b/scripts/cdist
@@ -26,8 +26,11 @@ def inspect_ssh_mux_opts(control_path_dir="~/.ssh/"):
     import subprocess
     import os
 
-    control_path = os.path.join(control_path_dir,
-            "cdist.socket.master-%l-%r@%h:%p")
+    # socket is always local to each cdist run, it is created in
+    # temp directory that is created at starting cdist, so 
+    # control_path file name can be static, it will always be
+    # unique due to unique temp directory name
+    control_path = os.path.join(control_path_dir, "ssh-control-path")
     wanted_mux_opts = {
         "ControlPath": control_path,
         "ControlMaster": "auto",
@@ -147,7 +150,7 @@ def commandline():
         # didn't specify command line options nor env vars:
         # inspect multiplexing options for default cdist.REMOTE_COPY/EXEC
         if args_dict['remote_copy'] is None or args_dict['remote_exec'] is None:
-            control_path_dir = tempfile.mkdtemp()
+            control_path_dir = tempfile.mkdtemp(prefix="cdist")
             import atexit
             atexit.register(lambda: shutil.rmtree(control_path_dir))
             mux_opts = inspect_ssh_mux_opts(control_path_dir)


### PR DESCRIPTION
Hi!

On some envs ssh multiplexing control path is too long.
For e.g. Linux defines max unis socket path to be 108 bytes.
So I shortened ControlPath cdist sets up by default.