### PR TITLE
Fix process error handling in local.

### DIFF
--- a/cdist/exec/local.py
+++ b/cdist/exec/local.py
@@ -207,14 +207,13 @@ class Local(object):
             env.update(message.env)
 
         try:
-            output = exec_util.call_get_output(command, env=env)
-            self.log.debug("Local output: {}".format(output))
+            output, errout = exec_util.call_get_output(command, env=env)
+            self.log.debug("Local stdout: {}".format(output))
+            self.log.debug("Local stderr: {}".format(errout))
             if return_output:
                 return output.decode()
         except subprocess.CalledProcessError as e:
-            raise cdist.Error("Command failed: " + " ".join(command)
-                    + " with returncode: {} and output: {}".format(
-                        e.returncode, e.output))
+            exec_util.handle_called_process_error(e, command)
         except OSError as error:
             raise cdist.Error(" ".join(command) + ": " + error.args[1])
         finally:


### PR DESCRIPTION
Fixed called process error handling in local.
Local is used for code generation (gencode-local and gencode-remote) and the output is used
as generated code. So if both stdout and stderr is redirected to stdout then generated script is
invalid. I separated outputs in local.