### PR TITLE
Better sphinx manpage ext. Add custom dotman Makefile target for custom .cdit directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,29 @@ man-latest-link: web-pub
 	ssh staticweb.ungleich.ch \
 		"cd /home/services/www/nico/nico.schottelius.org/www/software/cdist/man/ && rm -f latest && ln -sf "$(CHANGELOG_VERSION)" latest"
 
+# Manpages: .cdist Types
+DOT_CDIST_PATH=${HOME}/.cdist
+DOTMAN7DSTDIR=$(MAN7DSTDIR)
+DOTTYPEDIR=$(DOT_CDIST_PATH)/type
+$(info $(DOTTYPEDIR))
+DOTMANTYPESRC=$(shell ls $(DOTTYPEDIR)/*/man.rst)
+$(info $(DOTMANTYPESRC))
+DOTMANTYPEPREFIX=$(subst $(DOTTYPEDIR)/,$(DOTMAN7DSTDIR)/cdist-type,$(DOTMANTYPESRC))
+$(info $(DOTMANTYPEPREFIX))
+DOTMANTYPES=$(subst /man.rst,.rst,$(DOTMANTYPEPREFIX))
+$(info $(DOTMANTYPES))
+
+# Link manpage: do not create man.html but correct named file
+$(DOTMAN7DSTDIR)/cdist-type%.rst: $(DOTTYPEDIR)/%/man.rst
+	ln -sf "$^" $@
+
+# Manpages #3: generic part
+dotmansphinxman: $(DOTMANTYPES)
+	$(SPHINXM)
+
+dotman: dotmansphinxman
+
+
 ################################################################################
 # Speeches
 #

--- a/cdist/conf/type/__apt_key/man.rst
+++ b/cdist/conf/type/__apt_key/man.rst
@@ -1,6 +1,9 @@
 cdist-type__apt_key(7)
 ======================
-Manage the list of keys used by apt
+
+NAME
+----
+cdist-type__apt_key - Manage the list of keys used by apt
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__apt_key_uri/man.rst
+++ b/cdist/conf/type/__apt_key_uri/man.rst
@@ -1,6 +1,9 @@
 cdist-type__apt_key_uri(7)
 ==========================
-Add apt key from uri
+
+NAME
+----
+cdist-type__apt_key_uri - Add apt key from uri
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__apt_norecommends/man.rst
+++ b/cdist/conf/type/__apt_norecommends/man.rst
@@ -1,6 +1,9 @@
 cdist-type__apt_norecommends(7)
 ===============================
-Configure apt to not install recommended packages
+
+NAME
+----
+cdist-type__apt_norecommends - Configure apt to not install recommended packages
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__apt_ppa/man.rst
+++ b/cdist/conf/type/__apt_ppa/man.rst
@@ -1,6 +1,9 @@
 cdist-type__apt_ppa(7)
 ======================
-Manage ppa repositories
+
+NAME
+----
+cdist-type__apt_ppa - Manage ppa repositories
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__apt_source/man.rst
+++ b/cdist/conf/type/__apt_source/man.rst
@@ -1,6 +1,9 @@
 cdist-type__apt_source(7)
 =========================
-Manage apt sources
+
+NAME
+----
+cdist-type__apt_source - Manage apt sources
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__apt_update_index/man.rst
+++ b/cdist/conf/type/__apt_update_index/man.rst
@@ -1,6 +1,9 @@
 cdist-type__apt_update_index(7)
 ===============================
-Update apt's package index
+
+NAME
+----
+cdist-type__apt_update_index - Update apt's package index
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__block/man.rst
+++ b/cdist/conf/type/__block/man.rst
@@ -1,6 +1,9 @@
 cdist-type__block(7)
 ====================
-Manage blocks of text in files
+
+NAME
+----
+cdist-type__block - Manage blocks of text in files
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__ccollect_source/man.rst
+++ b/cdist/conf/type/__ccollect_source/man.rst
@@ -1,6 +1,9 @@
 cdist-type__ccollect_source(7)
 ==============================
-Manage ccollect sources
+
+NAME
+----
+cdist-type__ccollect_source - Manage ccollect sources
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__cdist/man.rst
+++ b/cdist/conf/type/__cdist/man.rst
@@ -1,6 +1,9 @@
 cdist-type__cdist(7)
 ====================
-Manage cdist installations
+
+NAME
+----
+cdist-type__cdist - Manage cdist installations
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__cdistmarker/man.rst
+++ b/cdist/conf/type/__cdistmarker/man.rst
@@ -1,6 +1,9 @@
 cdist-type__cdistmarker(7)
 ==========================
-Add a timestamped cdist marker.
+
+NAME
+----
+cdist-type__cdistmarker - Add a timestamped cdist marker.
 
 Daniel Maher <phrawzty+cdist--@--gmail.com>
 

--- a/cdist/conf/type/__config_file/man.rst
+++ b/cdist/conf/type/__config_file/man.rst
@@ -1,6 +1,9 @@
 cdist-type__config_file(7)
 ==========================
-Manages config files
+
+NAME
+----
+cdist-type__config_file - _Manages config files
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul/man.rst
+++ b/cdist/conf/type/__consul/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul(7)
 =====================
-Install consul
+
+NAME
+----
+cdist-type__consul - Install consul
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_agent/man.rst
+++ b/cdist/conf/type/__consul_agent/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_agent(7)
 ===========================
-Manage the consul agent
+
+NAME
+----
+cdist-type__consul_agent - Manage the consul agent
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_check/man.rst
+++ b/cdist/conf/type/__consul_check/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_check(7)
 =============================
-Manages consul checks
+
+NAME
+----
+cdist-type__consul_check - Manages consul checks
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_reload/man.rst
+++ b/cdist/conf/type/__consul_reload/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_reload(7)
 ============================
-Reload consul
+
+NAME
+----
+cdist-type__consul_reload - Reload consul
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_service/man.rst
+++ b/cdist/conf/type/__consul_service/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_service(7)
 =============================
-Manages consul services
+
+NAME
+----
+cdist-type__consul_service - Manages consul services
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_template/man.rst
+++ b/cdist/conf/type/__consul_template/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_template(7)
 ==============================
-Manage the consul-template service
+
+NAME
+----
+cdist-type__consul_template - Manage the consul-template service
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_template_template/man.rst
+++ b/cdist/conf/type/__consul_template_template/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_template_template(7)
 =======================================
-Manage consul-template templates
+
+NAME
+----
+cdist-type__consul_template_template - Manage consul-template templates
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_watch_checks/man.rst
+++ b/cdist/conf/type/__consul_watch_checks/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_watch_checks(7)
 ==================================
-Manages consul checks watches
+
+NAME
+----
+cdist-type__consul_watch_checks - Manages consul checks watches
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_watch_event/man.rst
+++ b/cdist/conf/type/__consul_watch_event/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_watch_event(7)
 =================================
-Manages consul event watches
+
+NAME
+----
+cdist-type__consul_watch_event - Manages consul event watches
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_watch_key/man.rst
+++ b/cdist/conf/type/__consul_watch_key/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_watch_key(7)
 ===============================
-Manages consul key watches
+
+NAME
+----
+cdist-type__consul_watch_key - Manages consul key watches
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_watch_keyprefix/man.rst
+++ b/cdist/conf/type/__consul_watch_keyprefix/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_watch_keyprefix(7)
 =====================================
-Manages consul keyprefix watches
+
+NAME
+----
+cdist-type__consul_watch_keyprefix - Manages consul keyprefix watches
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_watch_nodes/man.rst
+++ b/cdist/conf/type/__consul_watch_nodes/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_watch_nodes(7)
 =================================
-Manages consul nodes watches
+
+NAME
+----
+cdist-type__consul_watch_nodes - Manages consul nodes watches
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_watch_service/man.rst
+++ b/cdist/conf/type/__consul_watch_service/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_watch_service(7)
 ===================================
-Manages consul service watches
+
+NAME
+----
+cdist-type__consul_watch_service - Manages consul service watches
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__consul_watch_services/man.rst
+++ b/cdist/conf/type/__consul_watch_services/man.rst
@@ -1,6 +1,9 @@
 cdist-type__consul_watch_services(7)
 ====================================
-Manages consul services watches
+
+NAME
+----
+cdist-type__consul_watch_services - Manages consul services watches
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__cron/man.rst
+++ b/cdist/conf/type/__cron/man.rst
@@ -1,6 +1,9 @@
 cdist-type__cron(7)
 ===================
-Installs and manages cron jobs
+
+NAME
+----
+cdist-type__cron - Installs and manages cron jobs
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__debconf_set_selections/man.rst
+++ b/cdist/conf/type/__debconf_set_selections/man.rst
@@ -1,6 +1,9 @@
 cdist-type__debconf_set_selections(7)
 =====================================
-Setup debconf selections
+
+NAME
+----
+cdist-type__debconf_set_selections - Setup debconf selections
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__directory/man.rst
+++ b/cdist/conf/type/__directory/man.rst
@@ -1,6 +1,9 @@
 cdist-type__directory(7)
 ========================
-Manage a directory
+
+NAME
+----
+cdist-type__directory - Manage a directory
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__dog_vdi/man.rst
+++ b/cdist/conf/type/__dog_vdi/man.rst
@@ -1,6 +1,9 @@
 cdist-type__dog_vdi(7)
 ======================
-Manage Sheepdog VM images
+
+NAME
+----
+cdist-type__dog_vdi - Manage Sheepdog VM images
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__file/man.rst
+++ b/cdist/conf/type/__file/man.rst
@@ -1,6 +1,9 @@
 cdist-type__file(7)
 ===================
-Manage files.
+
+NAME
+----
+cdist-type__file - Manage files.
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__firewalld_rule/man.rst
+++ b/cdist/conf/type/__firewalld_rule/man.rst
@@ -1,6 +1,9 @@
 cdist-type__firewalld_rule(7)
 =============================
-Configure firewalld rules
+
+NAME
+----
+cdist-type__firewalld_rule - Configure firewalld rules
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__git/man.rst
+++ b/cdist/conf/type/__git/man.rst
@@ -1,6 +1,9 @@
 cdist-type__git(7)
 ==================
-Get and or keep git repositories up-to-date
+
+NAME
+----
+cdist-type__git -  Get and or keep git repositories up-to-date
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__group/man.rst
+++ b/cdist/conf/type/__group/man.rst
@@ -1,6 +1,9 @@
 cdist-type__group(7)
 ====================
-Manage groups
+
+NAME
+----
+cdist-type__group - Manage groups
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__hostname/man.rst
+++ b/cdist/conf/type/__hostname/man.rst
@@ -1,6 +1,9 @@
 cdist-type__hostname(7)
 =======================
-Set the hostname
+
+NAME
+----
+cdist-type__hostname - Set the hostname
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__iptables_apply/man.rst
+++ b/cdist/conf/type/__iptables_apply/man.rst
@@ -1,6 +1,9 @@
 cdist-type__iptables_apply(7)
 =============================
-Apply the rules
+
+NAME
+----
+cdist-type__iptables_apply - Apply the rules
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__iptables_rule/man.rst
+++ b/cdist/conf/type/__iptables_rule/man.rst
@@ -1,6 +1,9 @@
 cdist-type__iptables_rule(7)
 ============================
-Deploy iptable rulesets
+
+NAME
+----
+cdist-type__iptables_rule - Deploy iptable rulesets
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__issue/man.rst
+++ b/cdist/conf/type/__issue/man.rst
@@ -1,6 +1,9 @@
 cdist-type__issue(7)
 ====================
-Manage issue
+
+NAME
+----
+cdist-type__issue - Manage issue
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__jail/man.rst
+++ b/cdist/conf/type/__jail/man.rst
@@ -1,6 +1,9 @@
 cdist-type__jail(7)
 ===================
-Manage FreeBSD jails
+
+NAME
+----
+cdist-type__jail - Manage FreeBSD jails
 
 Jake Guffey <jake.guffey--@--jointheirstm.org>
 

--- a/cdist/conf/type/__jail_freebsd10/man.rst
+++ b/cdist/conf/type/__jail_freebsd10/man.rst
@@ -1,6 +1,9 @@
 cdist-type__jail_freebsd10(7)
 =============================
-Manage FreeBSD jails
+
+NAME
+----
+cdist-type__jail_freeebsd10 - Manage FreeBSD jails
 
 Jake Guffey <jake.guffey--@--jointheirstm.org>
 

--- a/cdist/conf/type/__jail_freebsd9/man.rst
+++ b/cdist/conf/type/__jail_freebsd9/man.rst
@@ -1,6 +1,9 @@
 cdist-type__jail_freebsd9(7)
 ============================
-Manage FreeBSD jails
+
+NAME
+----
+cdist-type__jail_freebsd9 - Manage FreeBSD jails
 
 Jake Guffey <jake.guffey--@--eprotex.com>
 

--- a/cdist/conf/type/__key_value/man.rst
+++ b/cdist/conf/type/__key_value/man.rst
@@ -1,6 +1,9 @@
 cdist-type__key_value(7)
 ========================
-Change property values in files
+
+NAME
+----
+cdist-type__key_value - Change property values in files
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__line/man.rst
+++ b/cdist/conf/type/__line/man.rst
@@ -1,6 +1,9 @@
 cdist-type__line(7)
 ===================
-Manage lines in files
+
+NAME
+----
+cdist-type__line - Manage lines in files
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__link/man.rst
+++ b/cdist/conf/type/__link/man.rst
@@ -1,6 +1,9 @@
 cdist-type__link(7)
 ===================
-Manage links (hard and symbolic)
+
+NAME
+----
+cdist-type__link - Manage links (hard and symbolic)
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__locale/man.rst
+++ b/cdist/conf/type/__locale/man.rst
@@ -1,6 +1,9 @@
 cdist-type__locale(7)
 =====================
-Configure locales
+
+NAME
+----
+cdit-type__locale - Configure locales
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__motd/man.rst
+++ b/cdist/conf/type/__motd/man.rst
@@ -1,6 +1,9 @@
 cdist-type__motd(7)
 ===================
-Manage message of the day
+
+NAME
+----
+cdist-type__motd - Manage message of the day
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__mount/man.rst
+++ b/cdist/conf/type/__mount/man.rst
@@ -1,6 +1,9 @@
 cdist-type__mount(7)
 ====================
-Manage filesystem mounts
+
+NAME
+----
+cdit-type__mount - Manage filesystem mounts
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__mysql_database/man.rst
+++ b/cdist/conf/type/__mysql_database/man.rst
@@ -1,6 +1,9 @@
 cdist-type__mysql_database(7)
 =============================
-Manage a MySQL database
+
+NAME
+----
+cdist-type__mysql_database - Manage a MySQL database
 
 Benedikt Koeppel <code@benediktkoeppel.ch>
 

--- a/cdist/conf/type/__package/man.rst
+++ b/cdist/conf/type/__package/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package(7)
 ======================
-Manage packages
+
+NAME
+----
+cdist-type__package - Manage packages
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__package_apt/man.rst
+++ b/cdist/conf/type/__package_apt/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_apt(7)
 ==========================
-Manage packages with apt-get
+
+NAME
+----
+cdist-type__package_apt - Manage packages with apt-get
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__package_emerge/man.rst
+++ b/cdist/conf/type/__package_emerge/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_emerge(7)
 =============================
-Manage packages with portage
+
+NAME
+----
+cdist-type__package_emerge - Manage packages with portage
 
 Thomas Oettli <otho--@--sfs.biz>
 

--- a/cdist/conf/type/__package_emerge_dependencies/man.rst
+++ b/cdist/conf/type/__package_emerge_dependencies/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_emerge_dependencies(7)
 ==========================================
-Install dependencies for __package_emerge
+
+NAME
+----
+cdist-type__package_emerge_dependencies - Install dependencies for __package_emerge
 
 Thomas Oettli <otho--@--sfs.biz>
 

--- a/cdist/conf/type/__package_luarocks/man.rst
+++ b/cdist/conf/type/__package_luarocks/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_luarocks(7)
 ===============================
-Manage luarocks packages
+
+NAME
+----
+cdist-type__package_luarocks - Manage luarocks packages
 
 Christian G. Warden <cwarden@xerus.org>
 

--- a/cdist/conf/type/__package_opkg/man.rst
+++ b/cdist/conf/type/__package_opkg/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_opkg(7)
 ===========================
-Manage packages with opkg
+
+NAME
+----
+cdist-type__package_opkg - Manage packages with opkg
 
 Giel van Schijndel <giel+cdist--@--mortis.eu>
 

--- a/cdist/conf/type/__package_pacman/man.rst
+++ b/cdist/conf/type/__package_pacman/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_pacman(7)
 =============================
-Manage packages with pacman
+
+NAME
+----
+cdist-type__package_pacman - Manage packages with pacman
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__package_pip/man.rst
+++ b/cdist/conf/type/__package_pip/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_pip(7)
 ==========================
-Manage packages with pip
+
+NAME
+----
+cdist-type__package_pip - Manage packages with pip
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__package_pkg_freebsd/man.rst
+++ b/cdist/conf/type/__package_pkg_freebsd/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_pkg_freebsd(7)
 ==================================
-Manage FreeBSD packages 
+
+NAME
+----
+cdist-type__package_pkg_freebsd - Manage FreeBSD packages 
 
 Jake Guffey <jake.guffey--@--eprotex.com>
 

--- a/cdist/conf/type/__package_pkg_openbsd/man.rst
+++ b/cdist/conf/type/__package_pkg_openbsd/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_pkg(7)
 ==========================
-Manage OpenBSD packages
+
+NAME
+----
+cdist-type__package_pkg - Manage OpenBSD packages
 
 Andi Brönnimann <andi-cdist--@--v-net.ch>
 

--- a/cdist/conf/type/__package_pkgng_freebsd/man.rst
+++ b/cdist/conf/type/__package_pkgng_freebsd/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_pkgng_freebsd(7)
 ====================================
-Manage FreeBSD packages with pkg-ng
+
+NAME
+----
+cdist-type__package_pkgng_freebsd - Manage FreeBSD packages with pkg-ng
 
 Jake Guffey <jake.guffey--@--eprotex.com>
 

--- a/cdist/conf/type/__package_rubygem/man.rst
+++ b/cdist/conf/type/__package_rubygem/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_rubygem(7)
 ==============================
-Manage rubygem packages
+
+NAME
+----
+cdist-type__package_rubygem - Manage rubygem packages
 
 Chase Allen James <nx-cdist@nu-ex.com>
 

--- a/cdist/conf/type/__package_update_index/man.rst
+++ b/cdist/conf/type/__package_update_index/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_update_index(7)
 ===================================
-Update the package index
+
+NAME
+----
+cdist-type__update_index - Update the package index
 
 Ricardo Catalinas Jiménez <jimenezrick--@--gmail.com>
 

--- a/cdist/conf/type/__package_upgrade_all/man.rst
+++ b/cdist/conf/type/__package_upgrade_all/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_upgrade_all(7)
 ==================================
-Upgrade all the installed packages
+
+NAME
+----
+cdist-type__package_upgrade_all - Upgrade all the installed packages
 
 Ricardo Catalinas Jiménez <jimenezrick--@--gmail.com>
 

--- a/cdist/conf/type/__package_yum/man.rst
+++ b/cdist/conf/type/__package_yum/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_yum(7)
 ==========================
-Manage packages with yum
+
+NAME
+----
+cdist-type__package_yum - Manage packages with yum
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__package_zypper/man.rst
+++ b/cdist/conf/type/__package_zypper/man.rst
@@ -1,6 +1,9 @@
 cdist-type__package_zypper(7)
 =============================
-Manage packages with zypper
+
+NAME
+----
+cdist-type__package_zypper - Manage packages with zypper
 
 Daniel Heule <hda--@--sfs.biz>
 

--- a/cdist/conf/type/__pacman_conf/man.rst
+++ b/cdist/conf/type/__pacman_conf/man.rst
@@ -1,6 +1,9 @@
 cdist-type__pacman_conf(7)
 ==========================
-Manage pacman configuration
+
+NAME
+----
+cdist-type__pacman_conf - Manage pacman configuration
 
 Dominique Roux <dominique.roux4@gmail.com>
 

--- a/cdist/conf/type/__pacman_conf_integrate/man.rst
+++ b/cdist/conf/type/__pacman_conf_integrate/man.rst
@@ -1,6 +1,9 @@
 cdist-type__pacman_conf_integrate(7)
 ====================================
-Integrate default pacman.conf to cdist conform and vice versa
+
+NAME
+----
+cdist-type__pacman_conf_integrate - Integrate default pacman.conf to cdist conform and vice versa
 
 Dominique Roux <dominique.roux4@gmail.com>
 

--- a/cdist/conf/type/__pf_apply/man.rst
+++ b/cdist/conf/type/__pf_apply/man.rst
@@ -1,12 +1,11 @@
 cdist-type__pf_apply(7)
 =======================
-Apply pf(4) ruleset on \*BSD
-
-Jake Guffey <jake.guffey--@--eprotex.com>
-
 
 NAME
 ----
+cdist-type__pf_apply - Apply pf(4) ruleset on \*BSD
+
+Jake Guffey <jake.guffey--@--eprotex.com>
 
 
 DESCRIPTION

--- a/cdist/conf/type/__pf_ruleset/man.rst
+++ b/cdist/conf/type/__pf_ruleset/man.rst
@@ -1,6 +1,9 @@
 cdist-type__pf_ruleset(7)
 =========================
-Copy a pf(4) ruleset to $__target_host
+
+NAME
+----
+cdist-type__pf_ruleset - Copy a pf(4) ruleset to $__target_host
 
 Jake Guffey <jake.guffey--@--eprotex.com>
 

--- a/cdist/conf/type/__postfix/man.rst
+++ b/cdist/conf/type/__postfix/man.rst
@@ -1,6 +1,9 @@
 cdist-type__postfix(7)
 ======================
-Install postfix
+
+NAME
+----
+cdist-type__postfix - Install postfix
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__postfix_master/man.rst
+++ b/cdist/conf/type/__postfix_master/man.rst
@@ -1,6 +1,9 @@
 cdist-type__postfix_master(7)
 =============================
-Configure postfix master.cf
+
+NAME
+----
+cdist-type__postfix_master - Configure postfix master.cf
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__postfix_postconf/man.rst
+++ b/cdist/conf/type/__postfix_postconf/man.rst
@@ -1,6 +1,9 @@
 cdist-type__postfix_postconf(7)
 ===============================
-Configure postfix main.cf
+
+NAME
+----
+cdist-type__postfix_postconf - Configure postfix main.cf
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__postfix_postmap/man.rst
+++ b/cdist/conf/type/__postfix_postmap/man.rst
@@ -1,6 +1,9 @@
 cdist-type__postfix_postmap(7)
 ==============================
-Run postmap on the given file
+
+NAME
+----
+cdist-type__postfix_postmap - Run postmap on the given file
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__postfix_reload/man.rst
+++ b/cdist/conf/type/__postfix_reload/man.rst
@@ -1,6 +1,9 @@
 cdist-type__postfix_reload(7)
 =============================
-Tell postfix to reload its configuration
+
+NAME
+----
+cdist-type__postfix_reload - Tell postfix to reload its configuration
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__postgres_database/man.rst
+++ b/cdist/conf/type/__postgres_database/man.rst
@@ -1,6 +1,9 @@
 cdist-type__postgres_database(7)
 ================================
-Create/drop postgres databases
+
+NAME
+----
+cdist-type__postgres_database - Create/drop postgres databases
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__postgres_role/man.rst
+++ b/cdist/conf/type/__postgres_role/man.rst
@@ -1,6 +1,9 @@
 cdist-type__postgres_role(7)
 ============================
-Manage postgres roles
+
+NAME
+----
+cdist-type__postgres_role - Manage postgres roles
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__process/man.rst
+++ b/cdist/conf/type/__process/man.rst
@@ -1,6 +1,9 @@
 cdist-type__process(7)
 ======================
-Start or stop process
+
+NAME
+----
+cdist-type__process - Start or stop process
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__pyvenv/man.rst
+++ b/cdist/conf/type/__pyvenv/man.rst
@@ -1,6 +1,9 @@
 cdist-type__pyvenv(7)
 =====================
-Create or remove python virtual environment
+
+NAME
+----
+cdist-type__pyvenv - Create or remove python virtual environment
 
 Darko Poljak <darko.poljak--@--gmail.com>
 

--- a/cdist/conf/type/__qemu_img/man.rst
+++ b/cdist/conf/type/__qemu_img/man.rst
@@ -1,6 +1,9 @@
 cdist-type__qemu_img(7)
 =======================
-Manage VM disk images
+
+NAME
+----
+cdist-type__qemu_img - Manage VM disk images
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__rbenv/man.rst
+++ b/cdist/conf/type/__rbenv/man.rst
@@ -1,6 +1,9 @@
 cdist-type__rbenv(7)
 ====================
-Manage rbenv installation
+
+NAME
+----
+cdist-type__rbenv - Manage rbenv installation
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__rsync/man.rst
+++ b/cdist/conf/type/__rsync/man.rst
@@ -1,6 +1,9 @@
 cdist-type__rsync(7)
 ====================
-Mirror directories using rsync
+
+NAME
+----
+cdist-type__rsync - Mirror directories using rsync
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__rvm/man.rst
+++ b/cdist/conf/type/__rvm/man.rst
@@ -1,6 +1,9 @@
 cdist-type__rvm(7)
 ==================
-Install rvm for a given user
+
+NAME
+----
+cdist-type__rvm - Install rvm for a given user
 
 Evax Software <contact@evax.fr>
 

--- a/cdist/conf/type/__rvm_gem/man.rst
+++ b/cdist/conf/type/__rvm_gem/man.rst
@@ -1,6 +1,9 @@
 cdist-type__rvm_gemset(7)
 ==========================
-Manage Ruby gems through rvm
+
+NAME
+----
+cdist-type__rvm_gemset - Manage Ruby gems through rvm
 
 Evax Software <contact@evax.fr>
 

--- a/cdist/conf/type/__rvm_gemset/man.rst
+++ b/cdist/conf/type/__rvm_gemset/man.rst
@@ -1,6 +1,9 @@
 cdist-type__rvm_gemset(7)
 ==========================
-Manage gemsets through rvm
+
+NAME
+----
+cdist-type__rvm_gemset - Manage gemsets through rvm
 
 Evax Software <contact@evax.fr>
 

--- a/cdist/conf/type/__rvm_ruby/man.rst
+++ b/cdist/conf/type/__rvm_ruby/man.rst
@@ -1,6 +1,9 @@
 cdist-type__rvm_ruby(7)
 =======================
-Manage ruby installations through rvm
+
+NAME
+----
+cdist-type__rvm_ruby - Manage ruby installations through rvm
 
 Evax Software <contact@evax.fr>
 

--- a/cdist/conf/type/__ssh_authorized_key/man.rst
+++ b/cdist/conf/type/__ssh_authorized_key/man.rst
@@ -1,6 +1,9 @@
 cdist-type__ssh_authorized_key(7)
 =================================
-Manage a single ssh authorized key entry
+
+NAME
+----
+cdist-type__ssh_authorized_key - Manage a single ssh authorized key entry
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__ssh_authorized_keys/man.rst
+++ b/cdist/conf/type/__ssh_authorized_keys/man.rst
@@ -1,6 +1,9 @@
 cdist-type__ssh_authorized_keys(7)
 ==================================
-Manage ssh authorized_keys files
+
+NAME
+----
+cdist-type__ssh_authorized_keys - Manage ssh authorized_keys files
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__ssh_dot_ssh/man.rst
+++ b/cdist/conf/type/__ssh_dot_ssh/man.rst
@@ -1,12 +1,11 @@
 cdist-type__ssh_dot_ssh(7)
 ==========================
-Manage .ssh directory
-
-Nico Schottelius <nico-cdist--@--schottelius.org>
-
 
 NAME
 ----
+cdist-type__ssh_dot_ssh - Manage .ssh directory
+
+Nico Schottelius <nico-cdist--@--schottelius.org>
 
 
 DESCRIPTION

--- a/cdist/conf/type/__staged_file/man.rst
+++ b/cdist/conf/type/__staged_file/man.rst
@@ -1,6 +1,9 @@
 cdist-type__staged_file(7)
 ==========================
-Manage staged files
+
+NAME
+----
+cdist-type__staged_file - Manage staged files
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__start_on_boot/man.rst
+++ b/cdist/conf/type/__start_on_boot/man.rst
@@ -1,6 +1,9 @@
 cdist-type__start_on_boot(7)
 ============================
-Manage stuff to be started at boot
+
+NAME
+----
+cdist-type__start_on_boot - Manage stuff to be started at boot
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__timezone/man.rst
+++ b/cdist/conf/type/__timezone/man.rst
@@ -1,6 +1,9 @@
 cdist-type__timezone(7)
 =======================
-Allows one to configure the desired localtime timezone.
+
+NAME
+----
+cdist-type__timezone - Allows one to configure the desired localtime timezone.
 
 Ramon Salvadó <rsalvado--@--gnuine--dot--com>
 

--- a/cdist/conf/type/__update_alternatives/man.rst
+++ b/cdist/conf/type/__update_alternatives/man.rst
@@ -1,6 +1,9 @@
 cdist-type__update_alternatives(7)
 ==================================
-Configure alternatives
+
+NAME
+----
+cdist-type__update_alternatives - Configure alternatives
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/cdist/conf/type/__user/man.rst
+++ b/cdist/conf/type/__user/man.rst
@@ -1,6 +1,9 @@
 cdist-type__user(7)
 ===================
-Manage users
+
+NAME
+----
+cdist-type__user - Manage users
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__user_groups/man.rst
+++ b/cdist/conf/type/__user_groups/man.rst
@@ -1,6 +1,9 @@
 cdist-type__user_groups(7)
 ==========================
-Manage user groups
+
+NAME
+----
+cdist-type__user_groups - Manage user groups
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__yum_repo/man.rst
+++ b/cdist/conf/type/__yum_repo/man.rst
@@ -1,6 +1,9 @@
 cdist-type__yum_repo(7)
 =======================
-Manage yum repositories
+
+NAME
+----
+cdist-type__yum_repo - Manage yum repositories
 
 Steven Armstrong <steven-cdist--@--armstrong.cc>
 

--- a/cdist/conf/type/__zypper_repo/man.rst
+++ b/cdist/conf/type/__zypper_repo/man.rst
@@ -1,6 +1,9 @@
 cdist-type__zypper_repo(7)
 ==========================
-Repository management with zypper
+
+NAME
+----
+cdist-type__zypper_repo - Repository management with zypper
 
 Daniel Heule <hda--@--sfs.biz>
 

--- a/cdist/conf/type/__zypper_service/man.rst
+++ b/cdist/conf/type/__zypper_service/man.rst
@@ -1,6 +1,9 @@
 cdist-type__zypper_service(7)
 =============================
-Service management with zypper
+
+NAME
+----
+cdist-type__zypper_service - Service management with zypper
 
 Daniel Heule <hda--@--sfs.biz>
 

--- a/cdist/sphinxext/manpage.py
+++ b/cdist/sphinxext/manpage.py
@@ -1,0 +1,80 @@
+import sphinx.builders.manpage
+import sphinx.writers.manpage
+from docutils.frontend import OptionParser
+from sphinx.util.console import bold, darkgreen
+from six import string_types
+from docutils.io import FileOutput
+from os import path
+from sphinx.util.nodes import inline_all_toctrees
+from sphinx import addnodes
+
+"""
+    Extension based on sphinx builtin manpage.
+    It does not write its own .SH NAME based on config,
+    but leaves everything to actual reStructuredText file content.
+"""
+
+class ManualPageTranslator(sphinx.writers.manpage.ManualPageTranslator):
+
+   def header(self):
+       tmpl = (".TH \"%(title_upper)s\" \"%(manual_section)s\""
+               " \"%(date)s\" \"%(version)s\" \"%(manual_group)s\"\n")
+       return tmpl % self._docinfo
+
+
+class ManualPageWriter(sphinx.writers.manpage.ManualPageWriter):
+
+    def __init__(self, builder):
+        super().__init__(builder)
+        self.translator_class = (
+                self.builder.translator_class or ManualPageTranslator)
+
+
+class ManualPageBuilder(sphinx.builders.manpage.ManualPageBuilder):
+
+    name = 'cman'
+
+    def write(self, *ignored):
+        docwriter = ManualPageWriter(self)
+        docsettings = OptionParser(
+            defaults=self.env.settings,
+            components=(docwriter,),
+            read_config_files=True).get_default_values()
+
+        self.info(bold('writing... '), nonl=True)
+
+        for info in self.config.man_pages:
+            docname, name, description, authors, section = info
+            if isinstance(authors, string_types):
+                if authors:
+                    authors = [authors]
+                else:
+                    authors = []
+
+            targetname = '%s.%s' % (name, section)
+            self.info(darkgreen(targetname) + ' { ', nonl=True)
+            destination = FileOutput(
+                destination_path=path.join(self.outdir, targetname),
+                encoding='utf-8')
+
+            tree = self.env.get_doctree(docname)
+            docnames = set()
+            largetree = inline_all_toctrees(self, docnames, docname, tree,
+                                            darkgreen, [docname])
+            self.info('} ', nonl=True)
+            self.env.resolve_references(largetree, docname, self)
+            # remove pending_xref nodes
+            for pendingnode in largetree.traverse(addnodes.pending_xref):
+                pendingnode.replace_self(pendingnode.children)
+
+            largetree.settings = docsettings
+            largetree.settings.title = name
+            largetree.settings.subtitle = description
+            largetree.settings.authors = authors
+            largetree.settings.section = section
+
+            docwriter.write(largetree, destination)
+        self.info()
+
+def setup(app):
+    app.add_builder(ManualPageBuilder)

--- a/docs/man/Makefile
+++ b/docs/man/Makefile
@@ -161,7 +161,7 @@ text:
 
 .PHONY: man
 man:
-	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
+	$(SPHINXBUILD) -b cman $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 

--- a/docs/man/cdist-reference.rst.sh
+++ b/docs/man/cdist-reference.rst.sh
@@ -37,7 +37,10 @@ exec > "$dest"
 cat << eof 
 cdist-reference(7)
 ==================
-Variable, path and type reference for cdist
+
+NAME
+----
+cdist-reference - Variable, path and type reference for cdist
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/conf.py
+++ b/docs/man/conf.py
@@ -29,7 +29,9 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = [
+    'cdist.sphinxext.manpage',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -257,15 +259,18 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-mandir = os.path.dirname(os.path.realpath(__file__))
-man_pages = []
+root_mandir = os.path.dirname(os.path.realpath(__file__))
+mandirs = []
 for mansubdir in ('man1', 'man7'):
-    for root, dirs, files in os.walk(os.path.join(mandir, mansubdir)):
+    mandirs.append((os.path.join(root_mandir, mansubdir), mansubdir[-1]))
+man_pages = []
+for mandir, section in mandirs:
+    for root, dirs, files in os.walk(mandir):
         for fname in files:
             froot, fext = os.path.splitext(fname)
             if fext == '.rst':
-                man_page = (os.path.join(mansubdir, froot), froot, '',
-                        [], mansubdir[-1])
+                man_page = (os.path.join('man' + str(section), froot),
+                        froot, '', [], section)
                 man_pages.append(man_page)
 
 #man_pages = [

--- a/docs/man/man1/cdist.rst
+++ b/docs/man/man1/cdist.rst
@@ -1,6 +1,9 @@
 cdist(1)
 ========
-Usable Configuration Management
+
+NAME
+----
+cdist - Usable Configuration Management
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/man7/cdist-best-practice.rst
+++ b/docs/man/man7/cdist-best-practice.rst
@@ -1,6 +1,9 @@
 cdist-best-practice(7)
 ======================
-Practices used in real environments
+
+NAME
+----
+cdist-best-practice - Practices used in real environments
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/man7/cdist-bootstrap.rst
+++ b/docs/man/man7/cdist-bootstrap.rst
@@ -1,6 +1,9 @@
 cdist-bootstrap(7)
 ==================
-Setup cdist environment
+
+NAME
+----
+cdist-bootstrap - Setup cdist environment
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/man7/cdist-explorer.rst
+++ b/docs/man/man7/cdist-explorer.rst
@@ -1,6 +1,9 @@
 cdist-explorer(7)
 =================
-Explore the target systems
+
+NAME
+----
+cdist-explorer - Explore the target systems
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/man7/cdist-hacker.rst
+++ b/docs/man/man7/cdist-hacker.rst
@@ -1,6 +1,9 @@
 cdist-hacker(7)
 ===============
-How to get (stuff) into cdist
+
+NAME
+----
+cdist-hacker - How to get (stuff) into cdist
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/man7/cdist-manifest.rst
+++ b/docs/man/man7/cdist-manifest.rst
@@ -1,6 +1,9 @@
 cdist-manifest(7)
 =================
-(Re-)Use types
+
+NAME
+----
+cdist-manifest - (Re-)Use types
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/man7/cdist-messaging.rst
+++ b/docs/man/man7/cdist-messaging.rst
@@ -1,6 +1,9 @@
 cdist-messaging(7)
 ==================
-How the initial manifest and types can communication
+
+NAME
+----
+cdist-messaging - How the initial manifest and types can communication
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/man7/cdist-quickstart.rst
+++ b/docs/man/man7/cdist-quickstart.rst
@@ -1,6 +1,9 @@
 cdist-quickstart(7)
 ===================
-Jump in and enjoy cdist
+
+NAME
+----
+cdist-quickstart - Jump in and enjoy cdist
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/man7/cdist-remote-exec-copy.rst
+++ b/docs/man/man7/cdist-remote-exec-copy.rst
@@ -1,6 +1,9 @@
 cdist-remote-exec-copy(7)
 =========================
-How to use remote exec and copy
+
+NAME
+----
+cdist-remote-exec-copy - How to use remote exec and copy
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/man7/cdist-stages.rst
+++ b/docs/man/man7/cdist-stages.rst
@@ -1,6 +1,9 @@
 cdist-stages(7)
 ===============
-Stages used during configuration deployment
+
+NAME
+----
+cdist-stages - Stages used during configuration deployment
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/man7/cdist-troubleshooting.rst
+++ b/docs/man/man7/cdist-troubleshooting.rst
@@ -1,6 +1,9 @@
 cdist-troubleshooting(7)
 ========================
-Common problems and their solutions
+
+NAME
+----
+cdist-troubleshooting - Common problems and their solutions
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/man7/cdist-tutorial.rst
+++ b/docs/man/man7/cdist-tutorial.rst
@@ -1,6 +1,9 @@
 cdist-tutorial(7)
 =================
-A guided introduction into cdist
+
+NAME
+----
+cdist-tutorial - A guided introduction into cdist
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 

--- a/docs/man/man7/cdist-type.rst
+++ b/docs/man/man7/cdist-type.rst
@@ -1,6 +1,9 @@
 cdist-type(7)
 =============
-Functionality bundled
+
+NAME
+----
+cdist-type - Functionality bundled
 
 Nico Schottelius <nico-cdist--@--schottelius.org>
 


### PR DESCRIPTION
@telmich I added sphinx extension for manpages.
Now NAME part is not created by manpage extension (in this way you need to specify all data in conf.py), it is up to rst content to have NAME part.

I also added dotman taget to cdist Makefile.
It creates man pages for all types in ~/.cdist directory.
It builds them into docs/man/_build/man directory as with builtin types.

Please review and say what do you think.