### PR TITLE
Make man pages SEE ALSO by convention. Improve docs building.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,9 @@ MANIFEST
 dist/
 cdist/version.py
 
-#sphinx build dir
+# sphinx build dirs, cache
 _build/
+docs/dist
 
 # Packaging: Archlinux
 /PKGBUILD

--- a/cdist/conf/type/__apt_key/man.rst
+++ b/cdist/conf/type/__apt_key/man.rst
@@ -48,12 +48,6 @@ EXAMPLES
     __apt_key UbuntuArchiveKey --keyid 437D05B5 --keyserver keyserver.ubuntu.com
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__apt_key_uri/man.rst
+++ b/cdist/conf/type/__apt_key_uri/man.rst
@@ -38,12 +38,6 @@ EXAMPLES
        --state present
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__apt_norecommends/man.rst
+++ b/cdist/conf/type/__apt_norecommends/man.rst
@@ -29,12 +29,6 @@ EXAMPLES
     __apt_norecommends
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__apt_ppa/man.rst
+++ b/cdist/conf/type/__apt_ppa/man.rst
@@ -37,12 +37,6 @@ EXAMPLES
     __apt_ppa ppa:sans-intern/missing-bits --state absent
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__apt_source/man.rst
+++ b/cdist/conf/type/__apt_source/man.rst
@@ -56,12 +56,6 @@ EXAMPLES
        --component partner --state present
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__apt_update_index/man.rst
+++ b/cdist/conf/type/__apt_update_index/man.rst
@@ -28,12 +28,6 @@ EXAMPLES
     __apt_update_index
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__block/man.rst
+++ b/cdist/conf/type/__block/man.rst
@@ -69,12 +69,6 @@ EXAMPLES
     DONE
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__ccollect_source/man.rst
+++ b/cdist/conf/type/__ccollect_source/man.rst
@@ -53,12 +53,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-ccollect(1)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-ccollect documentation at:
-<http://www.nico.schottelius.org/software/ccollect/>.
+:manpage:`ccollect`\ (1)
 
 
 AUTHORS

--- a/cdist/conf/type/__cdist/man.rst
+++ b/cdist/conf/type/__cdist/man.rst
@@ -50,12 +50,6 @@ EXAMPLES
     __cdist --source "git://git.schottelius.org/cdist" /home/cdist/cdist
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Nico Schottelius <nico-cdist--@--schottelius.org>

--- a/cdist/conf/type/__cdistmarker/man.rst
+++ b/cdist/conf/type/__cdistmarker/man.rst
@@ -42,12 +42,6 @@ EXAMPLES
     __cdistmarker --destination /tmp/cdist_marker --format '+%s'
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Daniel Maher <phrawzty+cdist--@--gmail.com>

--- a/cdist/conf/type/__config_file/man.rst
+++ b/cdist/conf/type/__config_file/man.rst
@@ -48,10 +48,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__file(7) <cdist-type__file.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__file`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__consul/man.rst
+++ b/cdist/conf/type/__consul/man.rst
@@ -41,12 +41,6 @@ EXAMPLES
        --version 0.4.1
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__consul_agent/man.rst
+++ b/cdist/conf/type/__consul_agent/man.rst
@@ -165,10 +165,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-consul documentation at:
-<http://www.consul.io/docs/agent/options.html>.
+consul documentation at: <http://www.consul.io/docs/agent/options.html>.
 
 
 AUTHORS

--- a/cdist/conf/type/__consul_check/man.rst
+++ b/cdist/conf/type/__consul_check/man.rst
@@ -62,10 +62,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__consul_agent(7) <cdist-type__consul_agent.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__consul_agent`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__consul_reload/man.rst
+++ b/cdist/conf/type/__consul_reload/man.rst
@@ -29,12 +29,6 @@ EXAMPLES
     __consul_reload
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__consul_service/man.rst
+++ b/cdist/conf/type/__consul_service/man.rst
@@ -66,10 +66,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__consul_agent(7) <cdist-type__consul_agent.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__consul_agent`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__consul_template/man.rst
+++ b/cdist/conf/type/__consul_template/man.rst
@@ -125,10 +125,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-consul documentation at:
-<https://github.com/hashicorp/consul-template>.
+consul documentation at: <https://github.com/hashicorp/consul-template>.
 
 
 AUTHORS

--- a/cdist/conf/type/__consul_template_template/man.rst
+++ b/cdist/conf/type/__consul_template_template/man.rst
@@ -59,11 +59,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__consul_template(7) <cdist-type__consul_template.html>`_,
-`cdist-type__consul_template_config(7) <cdist-type__consul_template_config.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__consul_template`\ (7), :manpage:`cdist-type__consul_template_config`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__consul_watch_checks/man.rst
+++ b/cdist/conf/type/__consul_watch_checks/man.rst
@@ -55,12 +55,9 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__consul_agent(7) <cdist-type__consul_agent.html>`_
+:manpage:`cdist-type__consul_agent`\ (7)
 
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-consul documentation at:
-<http://www.consul.io/docs/agent/watches.html>.
+consul documentation at: <http://www.consul.io/docs/agent/watches.html>.
 
 
 AUTHORS

--- a/cdist/conf/type/__consul_watch_event/man.rst
+++ b/cdist/conf/type/__consul_watch_event/man.rst
@@ -48,12 +48,9 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__consul_agent(7) <cdist-type__consul_agent.html>`_
+:manpage:`cdist-type__consul_agent`\ (7)
 
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-consul documentation at:
-<http://www.consul.io/docs/agent/watches.html>.
+consul documentation at: <http://www.consul.io/docs/agent/watches.html>.
 
 
 AUTHORS

--- a/cdist/conf/type/__consul_watch_key/man.rst
+++ b/cdist/conf/type/__consul_watch_key/man.rst
@@ -45,12 +45,9 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__consul_agent(7) <cdist-type__consul_agent.html>`_
+:manpage:`cdist-type__consul_agent`\ (7)
 
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-consul documentation at:
-<http://www.consul.io/docs/agent/watches.html>.
+consul documentation at: <http://www.consul.io/docs/agent/watches.html>.
 
 
 AUTHORS

--- a/cdist/conf/type/__consul_watch_keyprefix/man.rst
+++ b/cdist/conf/type/__consul_watch_keyprefix/man.rst
@@ -45,11 +45,9 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__consul_agent(7) <cdist-type__consul_agent.html>`_
+:manpage:`cdist-type__consul_agent`\ (7)
 
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-consule documentation at: <http://www.consul.io/docs/agent/watches.html>.
+consul documentation at: <http://www.consul.io/docs/agent/watches.html>.
 
 
 AUTHORS

--- a/cdist/conf/type/__consul_watch_nodes/man.rst
+++ b/cdist/conf/type/__consul_watch_nodes/man.rst
@@ -41,12 +41,9 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__consul_agent(7) <cdist-type__consul_agent.html>`_
+:manpage:`cdist-type__consul_agent`\ (7)
 
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-consul documentation at:
-<http://www.consul.io/docs/agent/watches.html>.
+consul documentation at: <http://www.consul.io/docs/agent/watches.html>.
 
 
 AUTHORS

--- a/cdist/conf/type/__consul_watch_service/man.rst
+++ b/cdist/conf/type/__consul_watch_service/man.rst
@@ -65,11 +65,9 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__consul_agent(7) <cdist-type__consul_agent.html>`_
+:manpage:`cdist-type__consul_agent`\ (7)
 
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-consule documentation at: <http://www.consul.io/docs/agent/watches.html>.
+consul documentation at: <http://www.consul.io/docs/agent/watches.html>.
 
 
 AUTHORS

--- a/cdist/conf/type/__consul_watch_services/man.rst
+++ b/cdist/conf/type/__consul_watch_services/man.rst
@@ -41,12 +41,9 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__consul_agent(7) <cdist-type__consul_agent.html>`_
+:manpage:`cdist-type__consul_agent`\ (7)
 
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-consul documentation at:
-<http://www.consul.io/docs/agent/watches.html>.
+consul documentation at: <http://www.consul.io/docs/agent/watches.html>.
 
 
 AUTHORS

--- a/cdist/conf/type/__cron/man.rst
+++ b/cdist/conf/type/__cron/man.rst
@@ -68,10 +68,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-crontab(5)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`crontab`\ (5)
 
 
 AUTHORS

--- a/cdist/conf/type/__debconf_set_selections/man.rst
+++ b/cdist/conf/type/__debconf_set_selections/man.rst
@@ -37,11 +37,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-debconf-set-selections(1),
-`cdist-type__update_alternatives(7) <cdist-type__update_alternatives.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`debconf-set-selections`\ (1), :manpage:`cdist-type__update_alternatives`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__directory/man.rst
+++ b/cdist/conf/type/__directory/man.rst
@@ -88,12 +88,6 @@ EXAMPLES
         --owner root --group root --mode 0755 --state present
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Nico Schottelius <nico-cdist--@--schottelius.org>

--- a/cdist/conf/type/__dog_vdi/man.rst
+++ b/cdist/conf/type/__dog_vdi/man.rst
@@ -43,10 +43,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-qemu(1), dog(8)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`qemu`\ (1), :manpage:`dog`\ (8)
 
 
 AUTHORS

--- a/cdist/conf/type/__file/man.rst
+++ b/cdist/conf/type/__file/man.rst
@@ -99,12 +99,6 @@ EXAMPLES
     DONE
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Nico Schottelius <nico-cdist--@--schottelius.org>

--- a/cdist/conf/type/__firewalld_rule/man.rst
+++ b/cdist/conf/type/__firewalld_rule/man.rst
@@ -65,11 +65,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__iptables_rule(7) <cdist-type__iptables_rule.html>`_,
-firewalld(8)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__iptables_rule`\ (7), :manpage:`firewalld`\ (8)
 
 
 AUTHORS

--- a/cdist/conf/type/__git/man.rst
+++ b/cdist/conf/type/__git/man.rst
@@ -47,12 +47,6 @@ EXAMPLES
     __git /home/nico/cdist --source git://github.com/telmich/cdist.git --branch 2.1
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Nico Schottelius <nico-cdist--@--schottelius.org>

--- a/cdist/conf/type/__group/man.rst
+++ b/cdist/conf/type/__group/man.rst
@@ -67,12 +67,6 @@ EXAMPLES
     __group foobar --gid 1234 --password 'crypted-password-string'
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__hostname/man.rst
+++ b/cdist/conf/type/__hostname/man.rst
@@ -39,12 +39,6 @@ EXAMPLES
     __hostname --name some-static-hostname
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__iptables_apply/man.rst
+++ b/cdist/conf/type/__iptables_apply/man.rst
@@ -29,11 +29,7 @@ None (__iptables_apply is used by __iptables_rule)
 
 SEE ALSO
 --------
-`cdist-type__iptables_rule(7) <cdist-type__iptables_rule.html>`_,
-iptables(8)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__iptables_rule`\ (7), :manpage:`iptables`\ (8)
 
 
 AUTHORS

--- a/cdist/conf/type/__iptables_rule/man.rst
+++ b/cdist/conf/type/__iptables_rule/man.rst
@@ -50,11 +50,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__iptables_apply(7) <cdist-type__iptables_apply.html>`_,
-iptables(8)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__iptables_apply`\ (7), :manpage:`iptables`\ (8)
 
 
 AUTHORS

--- a/cdist/conf/type/__issue/man.rst
+++ b/cdist/conf/type/__issue/man.rst
@@ -34,12 +34,6 @@ EXAMPLES
     __issue --source "$__type/files/myfancyissue"
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Nico Schottelius <nico-cdist--@--schottelius.org>

--- a/cdist/conf/type/__jail/man.rst
+++ b/cdist/conf/type/__jail/man.rst
@@ -108,8 +108,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`jail`\ (8)
 
 
 AUTHORS

--- a/cdist/conf/type/__jail_freebsd10/man.rst
+++ b/cdist/conf/type/__jail_freebsd10/man.rst
@@ -107,8 +107,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`jail`\ (8)
 
 
 AUTHORS

--- a/cdist/conf/type/__jail_freebsd9/man.rst
+++ b/cdist/conf/type/__jail_freebsd9/man.rst
@@ -108,8 +108,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`jail`\ (8)
 
 
 AUTHORS

--- a/cdist/conf/type/__key_value/man.rst
+++ b/cdist/conf/type/__key_value/man.rst
@@ -81,12 +81,6 @@ This type try to handle as many values as possible, so it doesn't use regexes.
 So you need to exactly specify the key and delimiter. Delimiter can be of any lenght.
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__line/man.rst
+++ b/cdist/conf/type/__line/man.rst
@@ -61,10 +61,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-grep(1)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`grep`\ (1)
 
 
 AUTHORS

--- a/cdist/conf/type/__link/man.rst
+++ b/cdist/conf/type/__link/man.rst
@@ -47,12 +47,6 @@ EXAMPLES
     __link /opt/plone --state absent
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Nico Schottelius <nico-cdist--@--schottelius.org>

--- a/cdist/conf/type/__locale/man.rst
+++ b/cdist/conf/type/__locale/man.rst
@@ -34,10 +34,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-locale(1), localedef(1)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`locale`\ (1), :manpage:`localedef`\ (1)
 
 
 AUTHORS

--- a/cdist/conf/type/__motd/man.rst
+++ b/cdist/conf/type/__motd/man.rst
@@ -35,12 +35,6 @@ EXAMPLES
     __motd --source "$__type/files/my-motd"
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Nico Schottelius <nico-cdist--@--schottelius.org>

--- a/cdist/conf/type/__mount/man.rst
+++ b/cdist/conf/type/__mount/man.rst
@@ -71,12 +71,6 @@ EXAMPLES
        --options "mfsmaster=mfsmaster.domain.tld,mfssubfolder=/one,nonempty,_netdev"
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__mysql_database/man.rst
+++ b/cdist/conf/type/__mysql_database/man.rst
@@ -36,12 +36,6 @@ EXAMPLES
     __mysql_database "cdist" --name "cdist" --user "myuser" --password "mypwd"
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Benedikt Koeppel <code@benediktkoeppel.ch>

--- a/cdist/conf/type/__package/man.rst
+++ b/cdist/conf/type/__package/man.rst
@@ -51,12 +51,6 @@ EXAMPLES
     __package vim --state present --type __package_apt
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__package_apt/man.rst
+++ b/cdist/conf/type/__package_apt/man.rst
@@ -46,10 +46,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__package_emerge/man.rst
+++ b/cdist/conf/type/__package_emerge/man.rst
@@ -47,11 +47,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_,
-`cdist-type__package_emerge_dependencies(7) <cdist-type__package_emerge_dependencies.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7), :manpage:`cdist-type__package_emerge_dependencies`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__package_emerge_dependencies/man.rst
+++ b/cdist/conf/type/__package_emerge_dependencies/man.rst
@@ -36,11 +36,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_,
-`cdist-type__package_emerge(7) <cdist-type__package_emerge.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7), :manpage:`cdist-type__package_emerge`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__package_luarocks/man.rst
+++ b/cdist/conf/type/__package_luarocks/man.rst
@@ -39,10 +39,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__package_opkg/man.rst
+++ b/cdist/conf/type/__package_opkg/man.rst
@@ -39,10 +39,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__package_pacman/man.rst
+++ b/cdist/conf/type/__package_pacman/man.rst
@@ -42,10 +42,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__package_pip/man.rst
+++ b/cdist/conf/type/__package_pip/man.rst
@@ -49,10 +49,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__package_pkg_freebsd/man.rst
+++ b/cdist/conf/type/__package_pkg_freebsd/man.rst
@@ -54,10 +54,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__package_pkg_openbsd/man.rst
+++ b/cdist/conf/type/__package_pkg_openbsd/man.rst
@@ -54,10 +54,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__package_pkgng_freebsd/man.rst
+++ b/cdist/conf/type/__package_pkgng_freebsd/man.rst
@@ -85,10 +85,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__package_rubygem/man.rst
+++ b/cdist/conf/type/__package_rubygem/man.rst
@@ -39,10 +39,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__package_update_index/man.rst
+++ b/cdist/conf/type/__package_update_index/man.rst
@@ -40,12 +40,6 @@ EXAMPLES
     __package_update_index --type apt
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Ricardo Catalinas Jiménez <jimenezrick--@--gmail.com>

--- a/cdist/conf/type/__package_upgrade_all/man.rst
+++ b/cdist/conf/type/__package_upgrade_all/man.rst
@@ -40,12 +40,6 @@ EXAMPLES
     __package_upgrade_all --type apt
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Ricardo Catalinas Jiménez <jimenezrick--@--gmail.com>

--- a/cdist/conf/type/__package_yum/man.rst
+++ b/cdist/conf/type/__package_yum/man.rst
@@ -49,10 +49,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__package_zypper/man.rst
+++ b/cdist/conf/type/__package_zypper/man.rst
@@ -56,10 +56,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__package(7) <cdist-type__package.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__package`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__pacman_conf/man.rst
+++ b/cdist/conf/type/__pacman_conf/man.rst
@@ -59,10 +59,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-grep(1)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`grep`\ (1)
 
 
 AUTHORS

--- a/cdist/conf/type/__pacman_conf_integrate/man.rst
+++ b/cdist/conf/type/__pacman_conf_integrate/man.rst
@@ -35,10 +35,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-grep(1)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`grep`\ (1)
 
 
 AUTHORS

--- a/cdist/conf/type/__pf_apply/man.rst
+++ b/cdist/conf/type/__pf_apply/man.rst
@@ -39,11 +39,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-pf(4),
-`cdist-type__pf_ruleset(7) <cdist-type__pf_ruleset.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`pf`\ (4), :manpage:`cdist-type__pf_ruleset`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__pf_ruleset/man.rst
+++ b/cdist/conf/type/__pf_ruleset/man.rst
@@ -39,10 +39,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-pf(4)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`pf`\ (4)
 
 
 AUTHORS

--- a/cdist/conf/type/__postfix/man.rst
+++ b/cdist/conf/type/__postfix/man.rst
@@ -29,12 +29,6 @@ EXAMPLES
     __postfix
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__postfix_master/man.rst
+++ b/cdist/conf/type/__postfix_master/man.rst
@@ -68,10 +68,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-master(5)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`master`\ (5)
 
 
 AUTHORS

--- a/cdist/conf/type/__postfix_postconf/man.rst
+++ b/cdist/conf/type/__postfix_postconf/man.rst
@@ -38,10 +38,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-postconf(5)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`postconf`\ (5)
 
 
 AUTHORS

--- a/cdist/conf/type/__postfix_postmap/man.rst
+++ b/cdist/conf/type/__postfix_postmap/man.rst
@@ -29,12 +29,6 @@ EXAMPLES
     __postfix_postmap /etc/postfix/generic
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__postfix_reload/man.rst
+++ b/cdist/conf/type/__postfix_reload/man.rst
@@ -29,12 +29,6 @@ EXAMPLES
     __postfix_reload
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__postgres_database/man.rst
+++ b/cdist/conf/type/__postgres_database/man.rst
@@ -30,10 +30,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__postgres_role(7) <cdist-type__postgres_role.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__postgres_role`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__postgres_role/man.rst
+++ b/cdist/conf/type/__postgres_role/man.rst
@@ -48,10 +48,8 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__postgres_database(7) <cdist-type__postgres_database.html>`_
+:manpage:`cdist-type__postgres_database`\ (7)
 
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
 postgresql documentation at:
 <http://www.postgresql.org/docs/current/static/sql-createrole.html>.
 

--- a/cdist/conf/type/__process/man.rst
+++ b/cdist/conf/type/__process/man.rst
@@ -58,10 +58,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__start_on_boot(7) <cdist-type__start_on_boot.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__start_on_boot`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__pyvenv/man.rst
+++ b/cdist/conf/type/__pyvenv/man.rst
@@ -67,12 +67,6 @@ EXAMPLES
     __pyvenv /home/services/djangoenv --venvparams "--copies --system-site-packages"
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Darko Poljak <darko.poljak--@--gmail.com>

--- a/cdist/conf/type/__qemu_img/man.rst
+++ b/cdist/conf/type/__qemu_img/man.rst
@@ -37,10 +37,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-qemu-img(1)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`qemu-img`\ (1)
 
 
 AUTHORS

--- a/cdist/conf/type/__rbenv/man.rst
+++ b/cdist/conf/type/__rbenv/man.rst
@@ -36,12 +36,6 @@ EXAMPLES
     __rbenv /home/bastian --state absent
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Nico Schottelius <nico-cdist--@--schottelius.org>

--- a/cdist/conf/type/__rsync/man.rst
+++ b/cdist/conf/type/__rsync/man.rst
@@ -98,10 +98,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-rsync(1)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`rsync`\ (1)
 
 
 AUTHORS

--- a/cdist/conf/type/__rvm/man.rst
+++ b/cdist/conf/type/__rvm/man.rst
@@ -31,12 +31,8 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__rvm_gem(7) <cdist-type__rvm_gem.html>`_,
-`cdist-type__rvm_gemset(7) <cdist-type__rvm_gemset.html>`_,
-`cdist-type__rvm_ruby(7) <cdist-type__rvm_ruby.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__rvm_gem`\ (7), :manpage:`cdist-type__rvm_gemset`\ (7),
+:manpage:`cdist-type__rvm_ruby`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__rvm_gem/man.rst
+++ b/cdist/conf/type/__rvm_gem/man.rst
@@ -43,12 +43,8 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__rvm(7) <cdist-type__rvm.html>`_,
-`cdist-type__rvm_gemset(7) <cdist-type__rvm_gemset.html>`_,
-`cdist-type__rvm_ruby(7) <cdist-type__rvm_ruby.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__rvm`\ (7), :manpage:`cdist-type__rvm_gemset`\ (7),
+:manpage:`cdist-type__rvm_ruby`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__rvm_gemset/man.rst
+++ b/cdist/conf/type/__rvm_gemset/man.rst
@@ -41,12 +41,8 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__rvm(7) <cdist-type__rvm.html>`_,
-`cdist-type__rvm_gem(7) <cdist-type__rvm_gem.html>`_,
-`cdist-type__rvm_ruby(7) <cdist-type__rvm_ruby.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__rvm`\ (7), :manpage:`cdist-type__rvm_gem`\ (7),
+:manpage:`cdist-type__rvm_ruby`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__rvm_ruby/man.rst
+++ b/cdist/conf/type/__rvm_ruby/man.rst
@@ -42,12 +42,8 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__rvm(7) <cdist-type__rvm.html>`_,
-`cdist-type__rvm_gem(7) <cdist-type__rvm_gem.html>`_,
-`cdist-type__rvm_gemset(7) <cdist-type__rvm_gemset.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__rvm`\ (7), :manpage:`cdist-type__rvm_gem`\ (7),
+:manpage:`cdist-type__rvm_gemset`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__ssh_authorized_key/man.rst
+++ b/cdist/conf/type/__ssh_authorized_key/man.rst
@@ -55,11 +55,8 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist__ssh_authorized_keys(7) <cdist__ssh_authorized_keys.html>`_,
-sshd(8)
+:manpage:`cdist__ssh_authorized_keys`\ (7), :manpage:`sshd`\ (8)
 
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
 
 AUTHORS
 -------

--- a/cdist/conf/type/__ssh_authorized_keys/man.rst
+++ b/cdist/conf/type/__ssh_authorized_keys/man.rst
@@ -105,10 +105,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-sshd(8)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`sshd`\ (8)
 
 
 AUTHORS

--- a/cdist/conf/type/__ssh_dot_ssh/man.rst
+++ b/cdist/conf/type/__ssh_dot_ssh/man.rst
@@ -33,10 +33,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__ssh_authorized_keys(7) <cdist-type__ssh_authorized_keys.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__ssh_authorized_keys`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__staged_file/man.rst
+++ b/cdist/conf/type/__staged_file/man.rst
@@ -99,10 +99,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__file(7) <cdist-type__file.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__file`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__start_on_boot/man.rst
+++ b/cdist/conf/type/__start_on_boot/man.rst
@@ -45,10 +45,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__process(7) <cdist-type__process.html>`_
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__process`\ (7)
 
 
 AUTHORS

--- a/cdist/conf/type/__timezone/man.rst
+++ b/cdist/conf/type/__timezone/man.rst
@@ -34,12 +34,6 @@ EXAMPLES
     __timezone US/Central
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Ramon Salvadó <rsalvado--@--gnuine--dot--com>

--- a/cdist/conf/type/__update_alternatives/man.rst
+++ b/cdist/conf/type/__update_alternatives/man.rst
@@ -30,11 +30,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-`cdist-type__debconf_set_selections(7) <cdist-type__debconf_set_selections.html>`_,
-update-alternatives(8)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`cdist-type__debconf_set_selections`\ (7), :manpage:`update-alternatives`\ (8)
 
 
 AUTHORS

--- a/cdist/conf/type/__user/man.rst
+++ b/cdist/conf/type/__user/man.rst
@@ -84,10 +84,7 @@ EXAMPLES
 
 SEE ALSO
 --------
-pw(8), usermod(8)
-
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
+:manpage:`pw`\ (8), :manpage:`usermod`\ (8)
 
 
 AUTHORS

--- a/cdist/conf/type/__user_groups/man.rst
+++ b/cdist/conf/type/__user_groups/man.rst
@@ -39,12 +39,6 @@ EXAMPLES
        --group webuser2 --state absent
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__yum_repo/man.rst
+++ b/cdist/conf/type/__yum_repo/man.rst
@@ -111,12 +111,6 @@ EXAMPLES
        --gpgkey https://fedoraproject.org/static/0608B895.txt
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>

--- a/cdist/conf/type/__zypper_repo/man.rst
+++ b/cdist/conf/type/__zypper_repo/man.rst
@@ -60,12 +60,6 @@ EXAMPLES
     __zypper_repo testrepo4 --state disabled --repo_id 4
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Daniel Heule <hda--@--sfs.biz>

--- a/cdist/conf/type/__zypper_service/man.rst
+++ b/cdist/conf/type/__zypper_service/man.rst
@@ -53,12 +53,6 @@ EXAMPLES
     __zypper_service INTERNAL_SLES11_SP3 --state absent --uri "http://path/to/your/ris/dir"
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>,
-especially cdist type chapter: <:cdist_docs:`cdist-type`>.
-
-
 AUTHORS
 -------
 Daniel Heule <hda--@--sfs.biz>

--- a/docs/man/Makefile
+++ b/docs/man/Makefile
@@ -5,7 +5,9 @@
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
-BUILDDIR      = _build
+BUILDDIR      = ../dist
+# for cache, etc.
+_BUILDDIR     = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -15,7 +17,7 @@ endif
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d $(_BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
@@ -52,6 +54,7 @@ help:
 .PHONY: clean
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf $(_BUILDDIR)/*
 
 .PHONY: html
 html:

--- a/docs/man/Makefile
+++ b/docs/man/Makefile
@@ -165,6 +165,10 @@ text:
 .PHONY: man
 man:
 	$(SPHINXBUILD) -b cman $(ALLSPHINXOPTS) $(BUILDDIR)/man
+	mkdir -p $(BUILDDIR)/man/man1
+	mkdir -p $(BUILDDIR)/man/man7
+	mv -f $(BUILDDIR)/man/*.1 $(BUILDDIR)/man/man1/
+	mv -f $(BUILDDIR)/man/*.7 $(BUILDDIR)/man/man7/
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 

--- a/docs/man/cdist-install.rst
+++ b/docs/man/cdist-install.rst
@@ -76,9 +76,9 @@ If you want to build and use the manpages, run:
 .. code-block:: sh
 
     make man
-    export MANPATH=$MANPATH:$(pwd -P)/docs/man/_build/man
+    export MANPATH=$MANPATH:$(pwd -P)/docs/dist/man
 
-Or you can move manpages from docs/man/_build/man directory to some
+Or you can move manpages from docs/dist/man directory to some
 other directory and add it to MANPATH.
 
 You can also build manpages for types in your ~/.cdist directory:
@@ -87,12 +87,23 @@ You can also build manpages for types in your ~/.cdist directory:
 
     make dotman
 
-Built manpages are now in docs/man/_build/man directory. If you have
-some other custom .cdist directory, e.g. /custom/.cdist then use:
+Built manpages are now in docs/dist/man directory. If you have
+some other custom .cdist directory, e.g. /opt/cdist then use:
 
 .. code-block:: sh
 
-    DOT_CDIST_PATH=/custom/.cdist make dotman
+    DOT_CDIST_PATH=/opt/cdist make dotman
+
+Building and using HTML documentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you want to build and use HTML documentation, run:
+
+.. code-block:: sh
+
+    make html
+
+Now you can access docs/dist/html/index.html.
 
 Python package
 ~~~~~~~~~~~~~~

--- a/docs/man/conf.py
+++ b/docs/man/conf.py
@@ -310,9 +310,3 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
-
-extlinks = {
-    'cdist_docs':
-        ('http://www.nico.schottelius.org/software/cdist/man/{}/%s.html'.format(
-            release), None),
-}

--- a/docs/man/man1/cdist.rst
+++ b/docs/man/man1/cdist.rst
@@ -175,10 +175,6 @@ The following exit values shall be returned:
     One or more host configurations failed
 
 
-SEE ALSO
---------
-Full documentation at: <:cdist_docs:`index`>.
-
 AUTHORS
 -------
 Nico Schottelius <nico-cdist--@--schottelius.org>


### PR DESCRIPTION
Hello!

Here are fixes for man pages.
@telmich These are fixes for issues that Dmitry reported.
Man pages should now be by convention, especially SEE ALSO part.
There is also imporvement in building docs.
sphinx target directory is changed to docs/dist so for users who install cdist from git and build docs can now access manpages from docs/dist/man and html documentation from docs/dist/html/index.html.