### PR TITLE
Add target_host file with original host to cache since cache dir is hash

### DIFF
--- a/cdist/exec/local.py
+++ b/cdist/exec/local.py
@@ -254,6 +254,10 @@ class Local(object):
                     "Cannot delete old cache %s: %s" % (destination, e))
 
         shutil.move(self.base_path, destination)
+        # add target_host since cache dir is hash-ed target_host
+        host_cache_path = os.path.join(destination, "target_host")
+        with open(host_cache_path, 'w') as hostf:
+            print(self.target_host[0], file=hostf)
 
     def _create_messages(self):
         """Create empty messages"""

--- a/cdist/exec/local.py
+++ b/cdist/exec/local.py
@@ -254,7 +254,7 @@ class Local(object):
                     "Cannot delete old cache %s: %s" % (destination, e))
 
         shutil.move(self.base_path, destination)
-        # add target_host since cache dir is hash-ed target_host
+        # add target_host since cache dir can be hash-ed target_host
         host_cache_path = os.path.join(destination, "target_host")
         with open(host_cache_path, 'w') as hostf:
             print(self.target_host[0], file=hostf)


### PR DESCRIPTION
@telmich What do you think?
Since target directory in cache is now hash, I think we should add file to host's cache directory with original target_host content.
It will help to find cache dir for particular target host.

It is a little change in save_cache method in exec/local.py.
