### PR TITLE
use /etc/os-release instead of /etc/SuSE-release

### DIFF
--- a/cdist/conf/explorer/os_version
+++ b/cdist/conf/explorer/os_version
@@ -61,7 +61,11 @@ case "$($__explorer/os)" in
       cat /etc/slackware-version
    ;;
    suse)
-      cat /etc/SuSE-release
+      if [ -f /etc/os-release ]; then
+        cat /etc/os-release
+      else
+        cat /etc/SuSE-release
+      fi
    ;;
    ubuntu)
       lsb_release -sr


### PR DESCRIPTION
2 facts are me leading to this change:

1.) See this comment in the /etc/SuSE-release file:
`# This file is deprecated and will be removed in a future service pack or release.`
`# Please check /etc/os-release for details about this release.`

2.) in the /etc/os-release file you could also differentiate for example normal SLES and SLES for SAP Application flavors ...

Thank you,
Daniel