### PR TITLE
__user type: fix for FreeBSD

### DIFF
--- a/cdist/conf/type/__user/gencode-remote
+++ b/cdist/conf/type/__user/gencode-remote
@@ -104,7 +104,7 @@ if [ "$state" = "present" ]; then
        if [ $# -gt 0 ]; then
           echo mod >> "$__messages_out"
           if [ "$os" = "freebsd" ]; then
-             echo pw usermod "$@" "$name"
+             echo pw usermod "$@" -n "$name"
           else
              echo usermod "$@" "$name"
           fi
@@ -125,7 +125,7 @@ if [ "$state" = "present" ]; then
         done
 
        if [ "$os" = "freebsd" ]; then
-          echo pw useradd "$@" "$name"
+          echo pw useradd "$@" -n "$name"
        else
           echo useradd "$@" "$name"
        fi


### PR DESCRIPTION
On FreeBSD, the `pw useradd` command should have either a different parameter order, or an explicit `-n $username` for the username. Tested on FreeBSD 11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ungleich/cdist/496)
<!-- Reviewable:end -->
