### PR TITLE
Cache subpath pattern

### DIFF
--- a/cdist/config.py
+++ b/cdist/config.py
@@ -292,7 +292,8 @@ class Config(object):
                 base_root_path=host_base_path,
                 host_dir_name=host_dir_name,
                 initial_manifest=args.manifest,
-                add_conf_dirs=args.conf_dir)
+                add_conf_dirs=args.conf_dir,
+                cache_path_pattern=args.cache_path_pattern)
 
             remote = cdist.exec.remote.Remote(
                 target_host=target_host,
@@ -328,7 +329,7 @@ class Config(object):
         self.manifest.run_initial_manifest(self.local.initial_manifest)
         self.iterate_until_finished()
 
-        self.local.save_cache()
+        self.local.save_cache(start_time)
         self.log.info("Finished successful run in %s seconds",
                       time.time() - start_time)
 

--- a/cdist/exec/local.py
+++ b/cdist/exec/local.py
@@ -64,6 +64,7 @@ class Local(object):
         self.exec_path = exec_path
         self.custom_initial_manifest = initial_manifest
         self._add_conf_dirs = add_conf_dirs
+        self.cache_path_pattern = cache_path_pattern
 
         self._init_log()
         self._init_permissions()

--- a/cdist/exec/local.py
+++ b/cdist/exec/local.py
@@ -31,7 +31,6 @@ import logging
 import tempfile
 import time
 import datetime
-import functools
 
 import cdist
 import cdist.message

--- a/cdist/test/exec/local.py
+++ b/cdist/test/exec/local.py
@@ -26,6 +26,8 @@ import getpass
 import shutil
 import string
 import random
+import time
+import datetime
 
 import cdist
 from cdist import test
@@ -223,6 +225,40 @@ class LocalTestCase(test.CdistTestCase):
         self.assertTrue(os.path.isdir(self.local.base_path))
         self.assertTrue(os.path.isdir(self.local.bin_path))
         self.assertTrue(os.path.isdir(self.local.conf_path))
+
+    def test_cache_subpath(self):
+        start_time = time.time()
+        dt = datetime.datetime.fromtimestamp(start_time)
+        pid = str(os.getpid())
+        cases = [
+            ['', self.local.hostdir, ],
+            ['/', self.local.hostdir, ],
+            ['//', self.local.hostdir, ],
+            ['/%%h', '%h', ],
+            ['%%h', '%h', ],
+            ['%P', pid, ],
+            ['x%P', 'x' + pid, ],
+            ['%h', self.hostdir, ],
+            ['%h/%Y-%m-%d/%H%M%S%f%P',
+             dt.strftime(self.hostdir + '/%Y-%m-%d/%H%M%S%f') + pid, ],
+            ['/%h/%Y-%m-%d/%H%M%S%f%P',
+             dt.strftime(self.hostdir + '/%Y-%m-%d/%H%M%S%f') + pid, ],
+            ['%Y-%m-%d/%H%M%S%f%P/%h',
+             dt.strftime('%Y-%m-%d/%H%M%S%f' + pid + os.sep + self.hostdir), ],
+            ['///%Y-%m-%d/%H%M%S%f%P/%h',
+             dt.strftime('%Y-%m-%d/%H%M%S%f' + pid + os.sep + self.hostdir), ],
+            ['%h/%Y-%m-%d/%H%M%S-%P',
+             dt.strftime(self.hostdir + '/%Y-%m-%d/%H%M%S-') + pid, ],
+            ['%Y-%m-%d/%H%M%S-%P/%h',
+             dt.strftime('%Y-%m-%d/%H%M%S-') + pid + os.sep + self.hostdir, ],
+        ]
+        for x in cases:
+            x.append(self.local._cache_subpath(start_time, x[0]))
+        # for fmt, expected, actual in cases:
+        #     print('\'{}\' \'{}\' \'{}\''.format(fmt, expected, actual))
+        for fmt, expected, actual in cases:
+            self.assertEqual(expected, actual)
+
 
 if __name__ == "__main__":
     import unittest

--- a/docs/changelog
+++ b/docs/changelog
@@ -2,6 +2,7 @@ Changelog
 ---------
 
 next:
+	* Core: support custom cache path pattern (Darko Poljak)
 	* Core, types: support IPv6 (Darko Poljak)
 	* Type __consul: add source and cksum files for Consul 0.7.0 and 0.7.1 (Carlos Ortigoza)
 	* Type __user: FreeBSD fix (Kamila Součková)

--- a/docs/src/cdist-reference.rst.sh
+++ b/docs/src/cdist-reference.rst.sh
@@ -273,4 +273,7 @@ CDIST_REMOTE_EXEC
 
 CDIST_REMOTE_COPY
     Use this command for remote copy (should behave like scp).
+
+CDIST_CACHE_PATH_PATTERN
+    Custom cache path pattern.
 eof

--- a/docs/src/man1/cdist.rst
+++ b/docs/src/man1/cdist.rst
@@ -15,14 +15,16 @@ SYNOPSIS
 
     cdist banner [-h] [-d] [-v]
 
-    cdist config [-h] [-d] [-v] [-b] [-c CONF_DIR] [-f HOSTFILE]
-                 [-i MANIFEST] [-j [JOBS]] [-n] [-o OUT_PATH] [-p] [-s]
-                 [--remote-copy REMOTE_COPY] [--remote-exec REMOTE_EXEC]
+    cdist config [-h] [-d] [-v] [-b] [-C CACHE_PATH_PATTERN] [-c CONF_DIR]
+                 [-f HOSTFILE] [-i MANIFEST] [-j [JOBS]] [-n] [-o OUT_PATH]
+                 [-p] [-s] [--remote-copy REMOTE_COPY]
+                 [--remote-exec REMOTE_EXEC]
                  [host [host ...]]
 
-    cdist install [-h] [-d] [-v] [-b] [-c CONF_DIR] [-f HOSTFILE]
-                  [-i MANIFEST] [-j [JOBS]] [-n] [-o OUT_PATH] [-p] [-s]
-                  [--remote-copy REMOTE_COPY] [--remote-exec REMOTE_EXEC]
+    cdist install [-h] [-d] [-v] [-b] [-C CACHE_PATH_PATTERN] [-c CONF_DIR]
+                  [-f HOSTFILE] [-i MANIFEST] [-j [JOBS]] [-n] [-o OUT_PATH]
+                  [-p] [-s] [--remote-copy REMOTE_COPY]
+                  [--remote-exec REMOTE_EXEC]
                   [host [host ...]]
 
     cdist shell [-h] [-d] [-v] [-s SHELL]
@@ -72,6 +74,13 @@ Configure/install one or more hosts.
     Enable beta functionalities. Beta functionalities include the
     following options: -j/--jobs.
 
+.. option:: -C CACHE_PATH_PATTERN, --cache-path-pattern CACHE_PATH_PATTERN
+
+    Sepcify custom cache path pattern. It can also be set by
+    CDIST_CACHE_PATH_PATTERN environment variable. If it is not set then
+    default hostdir is used. For more info on format see
+    :strong:`CACHE PATH PATTERN FORMAT` below.
+
 .. option:: -c CONF_DIR, --conf-dir CONF_DIR
 
     Add a configuration directory. Can be specified multiple times.
@@ -87,7 +96,8 @@ Configure/install one or more hosts.
     Read additional hosts to operate on from specified file
     or from stdin if '-' (each host on separate line).
     If no host or host file is specified then, by default,
-    read hosts from stdin. For the file format see below.
+    read hosts from stdin. For the file format see
+    :strong:`HOSTFILE FORMAT` below.
 
 .. option:: -i MANIFEST, --initial-manifest MANIFEST
 
@@ -134,6 +144,24 @@ Hostfile line is processed like the following. First, all comments are
 removed. Then all leading and trailing whitespace characters are stripped.
 If such a line results in empty line it is ignored/skipped. Otherwise,
 host string is used.
+
+
+CACHE PATH PATTERN FORMAT
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Cache path pattern specifies path for a cache directory subdirectory.
+In the path, '%h' will be substituted by the calculated host directory,
+'%P' will be substituted by the current process id. All format codes
+that :strong:`python` :strong:`datetime.strftime()` function supports, except
+'%h', are supported. These date/time directives format cdist config/install
+start time.
+
+If empty pattern is specified then default calculated host directory
+is used.
+
+Calculated host directory is a hash of a host cdist operates on.
+
+Resulting path is used to specify cache path subdirectory under which
+current host cache data are saved.
 
 
 SHELL
@@ -233,6 +261,9 @@ CDIST_REMOTE_EXEC
 
 CDIST_REMOTE_COPY
     Use this command for remote copy (should behave like scp).
+
+CDIST_CACHE_PATH_PATTERN
+    Custom cache path pattern.
 
 EXIT STATUS
 -----------

--- a/scripts/cdist
+++ b/scripts/cdist
@@ -115,7 +115,8 @@ def commandline():
     parser['config'].add_argument(
             '-C', '--cache_path_pattern',
             help=('Specify custom cache path pattern'),
-            dest='cache_path_pattern', required=False)
+            dest='cache_path_pattern',
+            default=os.environ.get('CDIST_CACHE_PATH_PATTERN'))
     parser['config'].add_argument(
             '-f', '--file',
             help=('Read additional hosts to operate on from specified file '

--- a/scripts/cdist
+++ b/scripts/cdist
@@ -113,6 +113,10 @@ def commandline():
             help=('Add configuration directory (can be repeated, '
                   'last one wins)'), action='append')
     parser['config'].add_argument(
+            '-C', '--cache_path_pattern',
+            help=('Specify custom cache path pattern'),
+            dest='cache_path_pattern', required=False)
+    parser['config'].add_argument(
             '-f', '--file',
             help=('Read additional hosts to operate on from specified file '
                   'or from stdin if \'-\' (each host on separate line). '

--- a/scripts/cdist
+++ b/scripts/cdist
@@ -109,14 +109,16 @@ def commandline():
                  'include the following options: -j/--jobs.'),
            action='store_true', dest='beta', default=False)
     parser['config'].add_argument(
+            '-C', '--cache-path-pattern',
+            help=('Specify custom cache path pattern. It can also be set '
+                  'by CDIST_CACHE_PATH_PATTERN environment variable. If '
+                  'it is not set then default hostdir is used.'),
+            dest='cache_path_pattern',
+            default=os.environ.get('CDIST_CACHE_PATH_PATTERN'))
+    parser['config'].add_argument(
             '-c', '--conf-dir',
             help=('Add configuration directory (can be repeated, '
                   'last one wins)'), action='append')
-    parser['config'].add_argument(
-            '-C', '--cache_path_pattern',
-            help=('Specify custom cache path pattern'),
-            dest='cache_path_pattern',
-            default=os.environ.get('CDIST_CACHE_PATH_PATTERN'))
     parser['config'].add_argument(
             '-f', '--file',
             help=('Read additional hosts to operate on from specified file '


### PR DESCRIPTION
Hello!

I added new option, -C, with which you can specify custom cache subpath pattern.
This pattern is then used to resolve actual cache directory path.
Resolved path is always used as a cache dir subpath.
Pattern supports all placeholders that python datetime.strftime function supports, except %h which
is used as a placeholder for calculated hostdir.
This is current value used and is a default if pattern is not specified or if it is empty.
Additionally %P placeholder is used and it will be substituted with current process id.

I used datetime.strftime function and not time.strftime function because datetime's support %f, microseconds.

Examples pattern resolutions are (in the format PATTERN RESOLVED_VALUE):
<pre>
'' '421aa90e079fa326b6494f812ad13e79'
'/' '421aa90e079fa326b6494f812ad13e79'
'//' '421aa90e079fa326b6494f812ad13e79'
'/%%h' '%h'
'%%h' '%h'
'%P' '3866'
'x%P' 'x3866'
'%h' '421aa90e079fa326b6494f812ad13e79'
'%h/%Y-%m-%d/%H%M%S%f%P' '421aa90e079fa326b6494f812ad13e79/2016-11-30/1804071970013866'
'/%h/%Y-%m-%d/%H%M%S%f%P' '421aa90e079fa326b6494f812ad13e79/2016-11-30/1804071970013866'
'%Y-%m-%d/%H%M%S%f%P/%h' '2016-11-30/1804071970013866/421aa90e079fa326b6494f812ad13e79'
'///%Y-%m-%d/%H%M%S%f%P/%h' '2016-11-30/1804071970013866/421aa90e079fa326b6494f812ad13e79'
'%h/%Y-%m-%d/%H%M%S-%P' '421aa90e079fa326b6494f812ad13e79/2016-11-30/180407-3866'
'%Y-%m-%d/%H%M%S-%P/%h' '2016-11-30/180407-3866/421aa90e079fa326b6494f812ad13e79'
</pre>

If pattern begins with '/', i.e. path separator, then all separators are removed.
If pattern is empty then default hostdir is used.
Default hostdir (currently used) is a hash of a host cdist operates on.

Pattern can also be specified using CDIST_CACHE_PATH_PATTERN env var.

@dheule This PR is a result of your old PR, so please take a look, even try it and send your feedback.
@telmich @asteven What do you think?

Caution.
If, for example, you use '%h/%Y-%m-%d' pattern and then you switch to default value, i.e., '%h',
when saving cache then destination tree is first removed.
This means you will lose '%Y-%m-%d' subdirectories.
**We should discuss on this further.**