### PR TITLE
Add optional arg to -v option

### DIFF
--- a/docs/src/man1/cdist.rst
+++ b/docs/src/man1/cdist.rst
@@ -50,10 +50,11 @@ All commands accept the following options:
 
 .. option:: -v, --verbose
 
-    Increase the verbosity level. Every instance of -v increments the verbosity
-    level by one. Its default value is 0. There are 4 levels of verbosity. The
-    order of levels from the lowest to the highest are: ERROR (0), WARNING (1),
-    INFO (2) and DEBUG (3 or higher).
+    Increase or set verbosity level. Every instance of -v increments the verbosity
+    level by one. Its default value is 0. You can specify the level directly, for
+    example -v2 or -v 3. There are 4 levels of verbosity. The order of levels from
+    the lowest to the highest are: ERROR (0), WARNING (1), INFO (2) and DEBUG
+    (3 or higher).
 
 .. option:: -V, --version
 


### PR DESCRIPTION
Added optional argument to -v option. Now one can also set verbosity level directly, for example, -v 3 -v2.
If -v is specified without an argument then every such instance increments verbosity level.
If -v with argument is specified after -v instances then argument value is set.
If -v instance is specified after -v with argument instance then verbosity value is first reset and then it increases with every -v instance.
Although now you cannot specify it like -vv or -vvv.

@telmich What do you think?