### PR TITLE
cache dir is not explicilty created

### DIFF
--- a/cdist/exec/local.py
+++ b/cdist/exec/local.py
@@ -149,6 +149,7 @@ class Local(object):
         self.mkdir(self.global_explorer_out_path)
         self.mkdir(self.object_path)
         self.mkdir(self.bin_path)
+        self.mkdir(self.cache_path)
 
     def create_files_dirs(self):
         self._init_directories()


### PR DESCRIPTION
The cache dir is not explicitly created.
Have never had a problem with this until running cdist inside a docker container.
The patch which will be added here shortly fixes the problem.
I have no real explanation for why this never showed before.

```
(appenv) ~ # echo "__hpc_euler_tuned" | cdist config -vv --out-dir /root/.cdist/out -i - eu-ms-002-01.hpc
-lca.ethz.ch
INFO: cdist: version 4.4.1
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Running global explorers
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Running global explorers sequentially
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Running initial manifest /tmp/cdist.stdin.b28gysoh
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Running manifest and explorers for __hpc_euler_tuned/
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Running manifest and explorers for __package/tuned
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Running manifest and explorers for __package_yum/tuned
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Generating code for __package_yum/tuned
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Generating code for __package/tuned
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Running manifest and explorers for __key_value/etc/tuned/tuned-main.conf:daemon
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Generating code for __key_value/etc/tuned/tuned-main.conf:daemon
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Running manifest and explorers for __directory/etc/tuned/ethz-hpc
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Generating code for __directory/etc/tuned/ethz-hpc
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Running manifest and explorers for __file/etc/tuned/ethz-hpc/tuned.conf
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Generating code for __file/etc/tuned/ethz-hpc/tuned.conf
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Running manifest and explorers for __file/etc/tuned/active_profile
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Generating code for __file/etc/tuned/active_profile
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Running manifest and explorers for __service/tuned
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Generating code for __service/tuned
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Executing code for __service/tuned
INFO: eu-ms-002-01.hpc-lca.ethz.ch: Generating code for __hpc_euler_tuned/
Traceback (most recent call last):
  File "/appenv/lib/python3.5/shutil.py", line 538, in move
    os.rename(src, real_dst)
FileNotFoundError: [Errno 2] No such file or directory: '/root/.cdist/out/7ae929a07a5503be8502613baec34e5e/data' -> '/root/.cdist/cache/7ae929a07a5503be8502613baec34e5e'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/appenv/bin/cdist", line 94, in <module>
    commandline()
  File "/appenv/bin/cdist", line 66, in commandline
    args.func(args)
  File "/appenv/lib/python3.5/site-packages/cdist/config.py", line 157, in commandline
    args, parallel=False)
  File "/appenv/lib/python3.5/site-packages/cdist/config.py", line 226, in onehost
    c.run()
  File "/appenv/lib/python3.5/site-packages/cdist/config.py", line 254, in run
    self.local.save_cache()
  File "/appenv/lib/python3.5/site-packages/cdist/exec/local.py", line 257, in save_cache
    shutil.move(self.base_path, destination)
  File "/appenv/lib/python3.5/shutil.py", line 549, in move
    symlinks=True)
  File "/appenv/lib/python3.5/shutil.py", line 353, in copytree
    raise Error(errors)
shutil.Error: [('/root/.cdist/out/7ae929a07a5503be8502613baec34e5e/data/conf/explorer/machine_type', '/root/.cdist/cache/7ae929a07a5503be8502613baec34e5e/conf/explorer/machine_type', "[Errno 95] Not supported: '/root/.cdist/cache/7ae929a07a5503be8502613baec34e5e/conf/explorer/machine_type'"),
...
long long list of all symlinks with Errno 95.
```