### PR TITLE
Shorten ssh control path.

### DIFF
--- a/docs/changelog
+++ b/docs/changelog
@@ -6,6 +6,7 @@ next:
 	* Type __go_get: Install go packages using go get (Kamila Součková)
 	* Explorer kernel_name: uname -s (Kamila Součková)
 	* Type __sysctl: Add devuan support (Nico Schottelius)
+	* Core: Shorten ssh control path (Darko Poljak)
 
 4.4.2: 2017-03-08
 	* Core: Fix suppression of manifests' outputs (Darko Poljak)


### PR DESCRIPTION
On macos the path is too long due to long default TMP dir.