### PR TITLE
Ignore dotfiles in types directory

### DIFF
--- a/cdist/core/cdist_type.py
+++ b/cdist/core/cdist_type.py
@@ -75,7 +75,9 @@ class CdistType(object):
     @classmethod
     def list_type_names(cls, base_path):
         """Return a list of type names"""
-        return os.listdir(base_path)
+        # Ignore files placed in the types directory by a VCS, package manager,
+        # file manager or the like.
+        return [i for i in os.listdir(base_path) if not i.startswith('.')]
 
     _instances = {}
 


### PR DESCRIPTION
When discovering types, `CdistType` iterates over all entries in `cdist/conf/type`. If anything places a file or directory there, the process fails:

    $ cdist -v config apu.feuermurmel.ch
    ERROR: apu.feuermurmel.ch: Type '.DS_Store' does not exist at /var/folders/r3/lpx2z49s5hs8mmh3vzrgxd9c0000gs/T/tmp4wkbjab2/805ef570a020944e9becf8a2f70ec03e/data/conf/type/.DS_Store
    ERROR: cdist: Failed to configure the following hosts: apu.feuermurmel.ch

In this case it was macOS' Finder which placed a `.DS_Store` file there while I was navigating the source tree.

This is my suggested fix for this type of problem. Please tell me if there's a better alternative.