### PR TITLE
Ignore directory entries that begin with dot('.').

### DIFF
--- a/cdist/core/cdist_object.py
+++ b/cdist/core/cdist_object.py
@@ -107,7 +107,7 @@ class CdistObject(object):
     @classmethod
     def list_type_names(cls, object_base_path):
         """Return a list of type names"""
-        return os.listdir(object_base_path)
+        return cdist.core.listdir(object_base_path)
 
     @staticmethod
     def split_name(object_name):

--- a/cdist/core/cdist_type.py
+++ b/cdist/core/cdist_type.py
@@ -23,6 +23,7 @@
 import os
 
 import cdist
+import cdist.core
 
 
 class NoSuchTypeError(cdist.Error):
@@ -75,7 +76,7 @@ class CdistType(object):
     @classmethod
     def list_type_names(cls, base_path):
         """Return a list of type names"""
-        return os.listdir(base_path)
+        return cdist.core.listdir(base_path)
 
     _instances = {}
 
@@ -117,8 +118,8 @@ class CdistType(object):
         """Return a list of available explorers"""
         if not self.__explorers:
             try:
-                self.__explorers = os.listdir(os.path.join(self.absolute_path,
-                                                           "explorer"))
+                self.__explorers = cdist.core.listdir(
+                    os.path.join(self.absolute_path, "explorer"))
             except EnvironmentError:
                 # error ignored
                 self.__explorers = []
@@ -222,7 +223,7 @@ class CdistType(object):
                 defaults_dir = os.path.join(self.absolute_path,
                                             "parameter",
                                             "default")
-                for name in os.listdir(defaults_dir):
+                for name in cdist.core.listdir(defaults_dir):
                     try:
                         with open(os.path.join(defaults_dir, name)) as fd:
                             defaults[name] = fd.read().strip()

--- a/cdist/core/util.py
+++ b/cdist/core/util.py
@@ -26,7 +26,10 @@ def listdir(path='.', include_dot=False):
     """os.listdir but do not include entries whose names begin with a dot('.')
        if include_dot is False.
     """
-    return [x for x in os.listdir(path) if include_dot or not _ishidden(x)]
+    if include_dot:
+        return os.listdir(path)
+    else:
+        return [x for x in os.listdir(path) if not _ishidden(x)]
 
 
 def _ishidden(path):

--- a/cdist/core/util.py
+++ b/cdist/core/util.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# 2010-2011 Steven Armstrong (steven-cdist at armstrong.cc)
-# 2014-2015 Nico Schottelius (nico-cdist at schottelius.org)
+# 2017 Darko Poljak (darko.poljak at gmail.com)
 #
 # This file is part of cdist.
 #
@@ -20,11 +19,15 @@
 #
 #
 
-from cdist.core.cdist_type import CdistType
-from cdist.core.cdist_type import NoSuchTypeError
-from cdist.core.cdist_object import CdistObject
-from cdist.core.cdist_object import IllegalObjectIdError
-from cdist.core.explorer import Explorer
-from cdist.core.manifest import Manifest
-from cdist.core.code import Code
-from cdist.core.util import listdir
+import os
+
+
+def listdir(path='.', include_dot=False):
+    """os.listdir but do not include entries whose names begin with a dot('.')
+       if include_dot is False.
+    """
+    return [x for x in os.listdir(path) if include_dot or not _ishidden(x)]
+
+
+def _ishidden(path):
+    return path[0] in ('.', b'.'[0])


### PR DESCRIPTION
Complete proposal of https://github.com/ungleich/cdist/pull/535 from @Feuermurmel:

> When discovering types, CdistType iterates over all entries in cdist/conf/type. If anything places a file or directory there, the process fails:
> 
> $ cdist -v config apu.feuermurmel.ch
> ERROR: apu.feuermurmel.ch: Type '.DS_Store' does not exist at /var/folders/r3/lpx2z49s5hs8mmh3vzrgxd9c0000gs/T/tmp4wkbjab2/805ef570a020944e9becf8a2f70ec03e/data/conf/type/.DS_Store
> ERROR: cdist: Failed to configure the following hosts: apu.feuermurmel.ch
> 
> In this case it was macOS' Finder which placed a .DS_Store file there while I was navigating the source tree.

@telmich @asteven Your thoughts?