### PR TITLE
Add -p HOST_MAX argument.

### DIFF
--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -152,9 +152,10 @@ def get_parsers():
     parser['config_main'].add_argument(
            '-j', '--jobs', nargs='?',
            type=check_positive_int,
-           help=('Specify the maximum number of parallel jobs. Global '
-                 'explorers, object prepare and object run are supported '
-                 '(currently in beta)'),
+           help=('Operate in parallel in specified maximum number of jobs. '
+                 'Global explorers, object prepare and object run are '
+                 'supported. Without argument CPU count is used by default. '
+                 'Currently in beta.'),
            action='store', dest='jobs',
            const=multiprocessing.cpu_count())
     parser['config_main'].add_argument(
@@ -204,13 +205,17 @@ def get_parsers():
                   'default, read hosts from stdin.'),
             dest='hostfile', required=False)
     parser['config_args'].add_argument(
-           '-p', '--parallel',
-           help='operate on multiple hosts in parallel',
-           action='store_true', dest='parallel')
+           '-p', '--parallel', nargs='?', metavar='HOST_MAX',
+           type=check_positive_int,
+           help=('Operate on multiple hosts in parallel for specified maximum '
+                 'hosts at a time. Without argument CPU count is used by '
+                 'default.'),
+           action='store', dest='parallel',
+           const=multiprocessing.cpu_count())
     parser['config_args'].add_argument(
            '-s', '--sequential',
            help='operate on multiple hosts sequentially (default)',
-           action='store_false', dest='parallel')
+           action='store_const', dest='parallel', const=0)
     parser['config_args'].add_argument(
              '-t', '--tag',
              help=('host is specified by tag, not hostname/address; '

--- a/docs/src/man1/cdist.rst
+++ b/docs/src/man1/cdist.rst
@@ -19,14 +19,14 @@ SYNOPSIS
                  [-i MANIFEST] [-j [JOBS]] [-n] [-o OUT_PATH]
                  [-r REMOTE_OUT_DIR] [--remote-copy REMOTE_COPY]
                  [--remote-exec REMOTE_EXEC] [-I INVENTORY_DIR] [-A] [-a]
-                 [-f HOSTFILE] [-p] [-s] [-t]
+                 [-f HOSTFILE] [-p [HOST_MAX]] [-s] [-t]
                  [host [host ...]] 
 
     cdist install [-h] [-q] [-v] [-b] [-C CACHE_PATH_PATTERN] [-c CONF_DIR]
                   [-i MANIFEST] [-j [JOBS]] [-n] [-o OUT_PATH]
                   [-r REMOTE_OUT_DIR] [--remote-copy REMOTE_COPY]
                   [--remote-exec REMOTE_EXEC] [-I INVENTORY_DIR] [-A] [-a]
-                  [-f HOSTFILE] [-p] [-s] [-t]
+                  [-f HOSTFILE] [-p [HOST_MAX]] [-s] [-t]
                   [host [host ...]] 
 
     cdist inventory [-h] [-q] [-v] [-b] [-I INVENTORY_DIR]
@@ -153,9 +153,10 @@ Configure/install one or more hosts.
 
 .. option:: -j [JOBS], --jobs [JOBS]
 
-    Specify the maximum number of parallel jobs. Global
-    explorers, object prepare and object run are supported
-    (currently in beta).
+    Operate in parallel in specified maximum number of
+    jobs. Global explorers, object prepare and object run
+    are supported. Without argument CPU count is used by
+    default. Currently in beta.
 
 .. option:: -n, --dry-run
 
@@ -165,9 +166,11 @@ Configure/install one or more hosts.
 
     Directory to save cdist output in
 
-.. option:: -p, --parallel
+.. option:: -p [HOST_MAX], --parallel [HOST_MAX]
 
-    Operate on multiple hosts in parallel
+    Operate on multiple hosts in parallel for specified
+    maximum hosts at a time. Without argument CPU count is
+    used by default.
 
 .. option:: -r REMOTE_OUT_PATH, --remote-out-dir REMOTE_OUT_PATH
 


### PR DESCRIPTION
When operating hosts in parallel do it in HOST_MAX maximum parallel host processes.
If argument is not specified, by default CPU count is used.