### PR TITLE
Add helpers for cdist config/install integration.

### DIFF
--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -1,5 +1,10 @@
 import argparse
 import cdist
+import cdist.banner
+import cdist.config
+import cdist.install
+import cdist.shell
+import cdist.inventory
 import multiprocessing
 import os
 import logging

--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -414,10 +414,10 @@ def handle_loglevel(args):
     logging.root.setLevel(_verbosity_level[args.verbose])
 
 
-def parse_and_configure(argv):
+def parse_and_configure(argv, singleton=True):
     parser = get_parsers()
     parser_args = parser['main'].parse_args(argv)
-    cfg = cdist.configuration.Configuration(parser_args)
+    cfg = cdist.configuration.Configuration(parser_args, singleton=singleton)
     args = cfg.get_args()
     # Loglevels are handled globally in here
     handle_loglevel(args)

--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -34,6 +34,9 @@ _verbosity_level = {
 }
 
 
+# Generate verbosity level constants:
+# VERBOSE_OFF, VERBOSE_ERROR, VERBOSE_WARNING, VERBOSE_INFO, VERBOSE_VERBOSE,
+# VERBOSE_DEBUG, VERBOSE_TRACE.
 this_globals = globals()
 for level in _verbosity_level:
     const = 'VERBOSE_' + logging.getLevelName(_verbosity_level[level])

--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -1,10 +1,5 @@
 import argparse
 import cdist
-import cdist.banner
-import cdist.config
-import cdist.install
-import cdist.shell
-import cdist.inventory
 import multiprocessing
 import logging
 import collections

--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -78,8 +78,6 @@ def check_beta(args_dict):
 
 
 def check_positive_int(value):
-    import argparse
-
     try:
         val = int(value)
     except ValueError:

--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -27,6 +27,14 @@ _verbosity_level = {
     3: logging.DEBUG,
     4: logging.TRACE,
 }
+
+
+this_globals = globals()
+for level in _verbosity_level:
+    const = 'VERBOSE_' + logging.getLevelName(_verbosity_level[level])
+    this_globals[const] = level
+
+
 # All verbosity levels above 4 are TRACE.
 _verbosity_level = collections.defaultdict(
     lambda: logging.TRACE, _verbosity_level)

--- a/cdist/config.py
+++ b/cdist/config.py
@@ -308,7 +308,8 @@ class Config(object):
                 initial_manifest=args.manifest,
                 add_conf_dirs=args.conf_dir,
                 cache_path_pattern=args.cache_path_pattern,
-                quiet_mode=args.quiet)
+                quiet_mode=args.quiet,
+                exec_path=sys.argv[0])
 
             remote = cdist.exec.remote.Remote(
                 target_host=target_host,

--- a/cdist/config.py
+++ b/cdist/config.py
@@ -299,6 +299,7 @@ class Config(object):
            so that main process knows for which host function was successful.
         """
 
+        print(args.cache_path_pattern)
         log = logging.getLogger(host)
 
         try:

--- a/cdist/config.py
+++ b/cdist/config.py
@@ -285,6 +285,7 @@ class Config(object):
         """Configure ONE system.
            If operating in parallel then return tuple (host, True|False, )
            so that main process knows for which host function was successful.
+           If operating in sequential mode then cls instance is returned.
         """
 
         log = logging.getLogger(host)
@@ -335,6 +336,8 @@ class Config(object):
 
         if parallel:
             return (host, True, )
+        else:
+            return c
 
     @staticmethod
     def create_base_root_path(out_path=None):

--- a/cdist/config.py
+++ b/cdist/config.py
@@ -299,7 +299,6 @@ class Config(object):
            so that main process knows for which host function was successful.
         """
 
-        print(args.cache_path_pattern)
         log = logging.getLogger(host)
 
         try:

--- a/cdist/configuration.py
+++ b/cdist/configuration.py
@@ -32,9 +32,12 @@ class Singleton(type):
     instance = None
 
     def __call__(cls, *args, **kwargs):
-        if not cls.instance:
-            cls.instance = super(Singleton, cls).__call__(*args, **kwargs)
-        return cls.instance
+        if 'singleton' in kwargs and kwargs['singleton'] == False:
+            return super(Singleton, cls).__call__(*args, **kwargs)
+        else:
+            if not cls.instance:
+                cls.instance = super(Singleton, cls).__call__(*args, **kwargs)
+            return cls.instance
 
 
 _VERBOSITY_VALUES = (
@@ -294,7 +297,7 @@ class Configuration(metaclass=Singleton):
             return None
 
     def __init__(self, command_line_args, env=os.environ,
-                 config_files=default_config_files):
+                 config_files=default_config_files, singleton=True):
         self.command_line_args = command_line_args
         self.args = self._convert_args(command_line_args)
         self.env = env

--- a/cdist/exec/remote.py
+++ b/cdist/exec/remote.py
@@ -111,6 +111,9 @@ class Remote(object):
         self.run(["chmod", "0700", self.base_path])
         self.mkdir(self.conf_path)
 
+    def remove_files_dirs(self):
+        self.rmdir(self.base_path)
+
     def rmfile(self, path):
         """Remove file on the remote side."""
         self.log.trace("Remote rm: %s", path)

--- a/cdist/integration.py
+++ b/cdist/integration.py
@@ -42,7 +42,7 @@ def _process_hosts_simple(action, host, manifest, verbose):
     else:
         raise cdist.Error('Invalid host argument: {}'.format(host))
 
-    # setup sys.argv[0] since cdist relies on command line invocation
+    # Setup sys.argv[0] since cdist relies on command line invocation.
     mydir = os.path.dirname(__file__)
     cdist_bin = os.path.abspath(os.path.join(mydir, '..', 'scripts', 'cdist'))
     sys.argv[0] = cdist_bin
@@ -51,6 +51,7 @@ def _process_hosts_simple(action, host, manifest, verbose):
     module = getattr(cdist, action)
     theclass = getattr(module, cname)
 
+    # Build argv for cdist - using argparse for argument parsing.
     argv = [action, '-i', manifest, ]
     for i in range(verbose):
         argv.append('-v')
@@ -73,10 +74,16 @@ def _process_hosts_simple(action, host, manifest, verbose):
 
 def configure_hosts_simple(host, manifest,
                            verbose=cdist.argparse.VERBOSE_INFO):
+    """Configure hosts with specified manifest using default other cdist
+       options. host parameter can be a string or iterbale of hosts.
+    """
     _process_hosts_simple(action=ACTION_CONFIG, host=host, manifest=manifest,
                           verbose=verbose)
 
 
 def install_hosts_simple(host, manifest, verbose=cdist.argparse.VERBOSE_INFO):
+    """Install hosts with specified manifest using default other cdist
+       options. host parameter can be a string or iterbale of hosts.
+    """
     _process_hosts_simple(action=ACTION_INSTALL, host=host, manifest=manifest,
                           verbose=verbose)

--- a/cdist/integration.py
+++ b/cdist/integration.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# 2017 Darko Poljak (darko.poljak at gmail.com)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+import cdist
+import cdist.log
+import cdist.config
+import cdist.install
+import cdist.argparse
+import argparse
+import sys
+import os.path
+
+
+ACTION_CONFIG = 'config'
+ACTION_INSTALL = 'install'
+
+
+def _process_host(action, host, manifest, verbose):
+    cname = action.title()
+    module = getattr(cdist, action)
+    theclass = getattr(module, cname)
+
+    args = argparse.Namespace()
+    args.manifest = manifest
+    args.parallel = 0
+    args.verbose = verbose
+    args.remote_copy = None
+    args.remote_exec = None
+    args.conf_dir = None
+    args.cache_path_pattern = None
+    args.quiet = False
+    args.all_tagged_hosts = False
+    args.beta = False
+    args.has_all_tags = False
+    args.remote_out_path = None
+    args.use_archiving = None
+    args.dry_run = False
+    args.jobs = None
+
+    cdist.argparse.handle_loglevel(args)
+    theclass.construct_remote_exec_copy_patterns(args)
+
+    base_root_path = theclass.create_base_root_path(None)
+    host_base_path, hostdir = theclass.create_host_base_dirs(host,
+                                                             base_root_path)
+    host_tags = None
+
+    # setup sys.argv[0] since cdist relies on command line invocation
+    mydir = os.path.dirname(__file__)
+    cdist_bin = os.path.abspath(os.path.join(mydir, '..', 'scripts', 'cdist'))
+    sys.argv[0] = cdist_bin
+    theclass.onehost(host, host_tags, host_base_path, hostdir, args,
+                     parallel=args.parallel > 0)
+
+
+def configure_host(host, manifest, verbose=cdist.argparse.VERBOSE_INFO):
+    _process_host(action=ACTION_CONFIG, host=host, manifest=manifest,
+                  verbose=verbose)
+
+
+def install_host(host, manifest, verbose=cdist.argparse.VERBOSE_INFO):
+    _process_host(action=ACTION_INSTALL, host=host, manifest=manifest,
+                  verbose=verbose)

--- a/cdist/integration.py
+++ b/cdist/integration.py
@@ -21,6 +21,12 @@
 #
 
 import cdist
+# needed for cdist.argparse
+import cdist.banner
+import cdist.config
+import cdist.install
+import cdist.shell
+import cdist.inventory
 import cdist.argparse
 import cdist.log
 import cdist.config
@@ -119,7 +125,7 @@ def _process_hosts_simple(action, host, manifest, verbose, cdist_path=None):
     for x in hosts:
         argv.append(x)
 
-    parser, cfg = cdist.argparse.parse_and_configure(argv[1:])
+    parser, cfg = cdist.argparse.parse_and_configure(argv)
     args = cfg.get_args()
     configuration = cfg.get_config(section='GLOBAL')
 

--- a/cdist/integration.py
+++ b/cdist/integration.py
@@ -50,7 +50,7 @@ def find_cdist_exec():
         return cdist_path
     cdist_path = find_cdist_exec_in_path()
     if not cdist_path:
-        raise cdist.Error('Cannot find cdist executable in local lib '
+        raise cdist.Error('Cannot find cdist executable from local lib '
                           'directory: {}, nor in PATH: {}.'.format(
                           _mydir, os.environ.get('PATH')))
     return cdist_path

--- a/cdist/integration.py
+++ b/cdist/integration.py
@@ -26,17 +26,16 @@ import cdist.config
 import cdist.install
 import cdist.argparse
 import sys
+import os
 import os.path
 import collections
 
 
 def find_cdist_exec_in_path():
-    paths = os.environ.get('PATH')
-    if paths:
-        for path in paths.split(os.pathsep):
-            cdist_path = os.path.join(path, 'cdist')
-            if os.access(cdist_path, os.X_OK):
-                return cdist_path
+    for path in os.get_exec_path():
+        cdist_path = os.path.join(path, 'cdist')
+        if os.access(cdist_path, os.X_OK):
+            return cdist_path
     return None
 
 
@@ -52,7 +51,7 @@ def find_cdist_exec():
     if not cdist_path:
         raise cdist.Error('Cannot find cdist executable from local lib '
                           'directory: {}, nor in PATH: {}.'.format(
-                          _mydir, os.environ.get('PATH')))
+                              _mydir, os.environ.get('PATH')))
     return cdist_path
 
 

--- a/cdist/integration.py
+++ b/cdist/integration.py
@@ -129,9 +129,8 @@ def _process_hosts_simple(action, host, manifest, verbose, cdist_path=None):
     for target_host in args.host:
         host_base_path, hostdir = theclass.create_host_base_dirs(
             target_host, base_root_path)
-        config_obj = theclass.onehost(target_host, None, host_base_path,
-                                      hostdir, args, parallel=False)
-        config_obj.remote.rmdir(out_dir)
+        theclass.onehost(target_host, None, host_base_path, hostdir, args,
+                         parallel=False, remove_remote_files_dirs=True)
         remote_out_dir.free(out_dir_index)
 
 

--- a/cdist/integration.py
+++ b/cdist/integration.py
@@ -21,10 +21,10 @@
 #
 
 import cdist
+import cdist.argparse
 import cdist.log
 import cdist.config
 import cdist.install
-import cdist.argparse
 import sys
 import os
 import os.path
@@ -119,9 +119,9 @@ def _process_hosts_simple(action, host, manifest, verbose, cdist_path=None):
     for x in hosts:
         argv.append(x)
 
-    parser = cdist.argparse.get_parsers()
-    args = parser['main'].parse_args(argv)
-    cdist.argparse.handle_loglevel(args)
+    parser, cfg = cdist.argparse.parse_and_configure(argv[1:])
+    args = cfg.get_args()
+    configuration = cfg.get_config(section='GLOBAL')
 
     theclass.construct_remote_exec_copy_patterns(args)
     base_root_path = theclass.create_base_root_path(None)
@@ -130,7 +130,8 @@ def _process_hosts_simple(action, host, manifest, verbose, cdist_path=None):
         host_base_path, hostdir = theclass.create_host_base_dirs(
             target_host, base_root_path)
         theclass.onehost(target_host, None, host_base_path, hostdir, args,
-                         parallel=False, remove_remote_files_dirs=True)
+                         parallel=False, configuration=configuration,
+                         remove_remote_files_dirs=True)
         remote_out_dir.free(out_dir_index)
 
 

--- a/cdist/integration.py
+++ b/cdist/integration.py
@@ -39,6 +39,8 @@ import uuid
 
 
 def find_cdist_exec_in_path():
+    """Search cdist executable in os.get_exec_path() entries.
+    """
     for path in os.get_exec_path():
         cdist_path = os.path.join(path, 'cdist')
         if os.access(cdist_path, os.X_OK):
@@ -50,6 +52,13 @@ _mydir = os.path.dirname(__file__)
 
 
 def find_cdist_exec():
+    """Search cdist executable starting from local lib directory.
+
+    Detect if ../scripts/cdist (from local lib direcotry) exists and
+    if it is executable. If not then try to find cdist exec path in
+    os.get_exec_path() entries. If no cdist path is found rasie
+    cdist.Error.
+    """
     cdist_path = os.path.abspath(os.path.join(_mydir, '..', 'scripts',
                                               'cdist'))
     if os.access(cdist_path, os.X_OK):
@@ -68,6 +77,12 @@ ACTION_INSTALL = 'install'
 
 def _process_hosts_simple(action, host, manifest, verbose,
                           cdist_path=None):
+    """Perform cdist action ('config' or 'install') on hosts with specified
+       manifest using default other cdist options. host parameter can be a
+       string or iterbale of hosts. verbose is a desired verbosity level
+       which defaults to VERBOSE_INFO. cdist_path is path to cdist executable,
+       if it is None then integration lib tries to find it.
+    """
     if isinstance(host, str):
         hosts = [host, ]
     elif isinstance(host, collections.Iterable):
@@ -114,7 +129,8 @@ def configure_hosts_simple(host, manifest,
                            verbose=cdist.argparse.VERBOSE_INFO,
                            cdist_path=None):
     """Configure hosts with specified manifest using default other cdist
-       options. host parameter can be a string or iterbale of hosts.
+       options. host parameter can be a string or iterbale of hosts. verbose
+       is a desired verbosity level which defaults to VERBOSE_INFO.
        cdist_path is path to cdist executable, if it is None then integration
        lib tries to find it.
     """
@@ -127,7 +143,8 @@ def install_hosts_simple(host, manifest,
                          verbose=cdist.argparse.VERBOSE_INFO,
                          cdist_path=None):
     """Install hosts with specified manifest using default other cdist
-       options. host parameter can be a string or iterbale of hosts.
+       options. host parameter can be a string or iterbale of hosts. verbose
+       is a desired verbosity level which defaults to VERBOSE_INFO.
        cdist_path is path to cdist executable, if it is None then integration
        lib tries to find it.
     """

--- a/cdist/test/configuration/__init__.py
+++ b/cdist/test/configuration/__init__.py
@@ -236,8 +236,15 @@ class ConfigurationTestCase(test.CdistTestCase):
         x = cc.Configuration(None)
         args = argparse.Namespace()
         args.a = 'a'
-        y = cc.Configuration()
+        y = cc.Configuration(args)
         self.assertIs(x, y)
+
+    def test_non_singleton(self):
+        x = cc.Configuration(None, singleton=False)
+        args = argparse.Namespace()
+        args.a = 'a'
+        y = cc.Configuration(args, singleton=False)
+        self.assertIsNot(x, y)
 
     def test_read_config_file(self):
         config = cc.Configuration(None, env={}, config_files=())

--- a/docs/src/cdist-integration.rst
+++ b/docs/src/cdist-integration.rst
@@ -19,6 +19,8 @@ options default values will be used.
 
 In case of cdist error :strong:`cdist.Error` exception is raised.
 
+:strong:`WARNING`: cdist integration helper functions are not yet stable!
+
 Examples
 --------
 

--- a/docs/src/cdist-integration.rst
+++ b/docs/src/cdist-integration.rst
@@ -17,6 +17,8 @@ Functions require `host` and `manifest` parameters.
 of hosts. `manifest` is a path to initial manifest. For other cdist
 options default values will be used.
 
+In case of cdist error :strong:`cdist.Error` exception is raised.
+
 Examples
 --------
 

--- a/docs/src/cdist-integration.rst
+++ b/docs/src/cdist-integration.rst
@@ -15,9 +15,10 @@ functions:
 Functions require `host` and `manifest` parameters.
 `host` can be specified as a string representing host or as iterable
 of hosts. `manifest` is a path to initial manifest. For other cdist
-options default values will be used. `cdist_path` parameter specifies
+options default values will be used. `verbose` is a desired verbosity
+level which defaults to VERBOSE_INFO. `cdist_path` parameter specifies
 path to cdist executable, if it is `None` then functions will try to
-find it first in local lib directory and then in PATH.
+find it first from local lib directory and then in PATH.
 
 In case of cdist error :strong:`cdist.Error` exception is raised.
 

--- a/docs/src/cdist-integration.rst
+++ b/docs/src/cdist-integration.rst
@@ -34,7 +34,7 @@ Examples
     >>> cdist.integration.configure_hosts_simple('185.203.114.185',
     ...                                          '~/.cdist/manifest/init')
 
-    # configure host from python interactive shell, specifiying verbosity level
+    # configure host from python interactive shell, specifying verbosity level
     >>> import cdist.integration
     >>> cdist.integration.configure_hosts_simple(
     ...     '185.203.114.185', '~/.cdist/manifest/init',

--- a/docs/src/cdist-integration.rst
+++ b/docs/src/cdist-integration.rst
@@ -15,7 +15,9 @@ functions:
 Functions require `host` and `manifest` parameters.
 `host` can be specified as a string representing host or as iterable
 of hosts. `manifest` is a path to initial manifest. For other cdist
-options default values will be used.
+options default values will be used. `cdist_path` parameter specifies
+path to cdist executable, if it is `None` then functions will try to
+find it first in local lib directory and then in PATH.
 
 In case of cdist error :strong:`cdist.Error` exception is raised.
 

--- a/docs/src/cdist-integration.rst
+++ b/docs/src/cdist-integration.rst
@@ -1,0 +1,40 @@
+cdist integration / using cdist as library
+==========================================
+
+Description
+-----------
+
+cdist can be integrate with other applications by importing cdist and other
+cdist modules and setting all by hand. There are also helper functions which
+aim to ease this integration. Just import **cdist.integration** and use its
+functions:
+
+* :strong:`cdist.integration.configure_hosts_simple` for configuration
+* :strong:`cdist.integration.install_hosts_simple` for installation.
+
+Functions require `host` and `manifest` parameters.
+`host` can be specified as a string representing host or as iterable
+of hosts. `manifest` is a path to initial manifest. For other cdist
+options default values will be used.
+
+Examples
+--------
+
+.. code-block:: sh
+
+    # configure host from python interactive shell
+    >>> import cdist.integration
+    >>> cdist.integration.configure_hosts_simple('185.203.114.185',
+    ...                                          '~/.cdist/manifest/init')
+
+    # configure host from python interactive shell, specifiying verbosity level
+    >>> import cdist.integration
+    >>> cdist.integration.configure_hosts_simple(
+    ...     '185.203.114.185', '~/.cdist/manifest/init',
+    ...     verbose=cdist.argparse.VERBOSE_TRACE)
+
+    # configure specified dns hosts from python interactive shell
+    >>> import cdist.integration
+    >>> hosts = ('dns1.ungleich.ch', 'dns2.ungleich.ch', 'dns3.ungleich.ch', )
+    >>> cdist.integration.configure_hosts_simple(hosts,
+    ...                                          '~/.cdist/manifest/init')

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -25,6 +25,7 @@ Contents:
    cdist-messaging
    cdist-parallelization
    cdist-inventory
+   cdist-integration
    cdist-reference
    cdist-best-practice
    cdist-stages


### PR DESCRIPTION
Added helper functions for cdist config/install integration, e.g. with django web.
You can configure a host from python shell using these helpers:
<pre>
>>> import cdist.integration
>>> cdist.integration.configure_hosts_simple('185.203.114.185', '/home/darko/.cdist/manifest/init', verbose=cdist.argparse.VERBOSE_TRACE)
</pre>

You should provide your own manifest file and verbose level (default is INFO).