### PR TITLE
Fix remote cmds cleanup

### DIFF
--- a/cdist/config.py
+++ b/cdist/config.py
@@ -80,6 +80,7 @@ class Config(object):
     @staticmethod
     def construct_remote_exec_copy_patterns(args):
         # default remote cmd patterns
+        args.remote_cmds_cleanup_pattern = ""
         args.remote_exec_pattern = None
         args.remote_copy_pattern = None
 
@@ -270,7 +271,7 @@ class Config(object):
             remote_copy = args.remote_copy_pattern.format(control_path)
         else:
             remote_copy = args.remote_copy
-        if 'remote_cmds_cleanup_pattern' in args:
+        if args.remote_cmds_cleanup_pattern:
             remote_cmds_cleanup = args.remote_cmds_cleanup_pattern.format(
                 control_path)
         else:

--- a/cdist/config.py
+++ b/cdist/config.py
@@ -270,7 +270,7 @@ class Config(object):
             remote_copy = args.remote_copy_pattern.format(control_path)
         else:
             remote_copy = args.remote_copy
-        if args.remote_cmds_cleanup_pattern:
+        if 'remote_cmds_cleanup_pattern' in args:
             remote_cmds_cleanup = args.remote_cmds_cleanup_pattern.format(
                 control_path)
         else:


### PR DESCRIPTION
When --remote-copy and --remote-exec are provided,
args.remote_cmds_cleanup_pattern is not set.

This patches fixes the evaluation of args.remote_cmds_cleanup_pattern
and prevents cdist from throwing an exception when --remote-copy
and --remote-exec are used.