### PR TITLE
explorer/os: get ID from /etc/os-release

### DIFF
--- a/cdist/conf/explorer/os
+++ b/cdist/conf/explorer/os
@@ -141,10 +141,10 @@ case "$uname_s" in
 esac
 
 if [ -f /etc/os-release ]; then
-	# already lowercase, according to:
-	# https://www.freedesktop.org/software/systemd/man/os-release.html
-	grep '^ID=' /etc/os-release | sed -e 's|^ID=||'
-	exit 0
+   # already lowercase, according to:
+   # https://www.freedesktop.org/software/systemd/man/os-release.html
+   grep '^ID=' /etc/os-release | sed -e 's|^ID=||'
+   exit 0
 fi
 
 echo "Unknown OS" >&2

--- a/cdist/conf/explorer/os
+++ b/cdist/conf/explorer/os
@@ -143,7 +143,7 @@ esac
 if [ -f /etc/os-release ]; then
    # already lowercase, according to:
    # https://www.freedesktop.org/software/systemd/man/os-release.html
-   grep '^ID=' /etc/os-release | sed -e 's|^ID=||'
+   awk -F= '/^ID=/ {print $2;}' /etc/os-release
    exit 0
 fi
 

--- a/cdist/conf/explorer/os
+++ b/cdist/conf/explorer/os
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # 2010-2011 Nico Schottelius (nico-cdist at schottelius.org)
+# Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
 #
 # This file is part of cdist.
 #
@@ -138,6 +139,13 @@ case "$uname_s" in
       exit 0
    ;;
 esac
+
+if [ -f /etc/os-release ]; then
+	# already lowercase, according to:
+	# https://www.freedesktop.org/software/systemd/man/os-release.html
+	grep '^ID=' /etc/os-release | sed -e 's|^ID=||'
+	exit 0
+fi
 
 echo "Unknown OS" >&2
 exit 1


### PR DESCRIPTION
/etc/os-release was introduced by systemd[1] and is now
more and more common; even on systems without systemd (e.g. lede).
In addition to detecting the OS based on specific attributes,
this file provides the ID marker to describe the OS.

This commit adds support for OS detection via /etc/os-release.
According to [2], it is already lowercase.

[1] http://0pointer.de/blog/projects/os-release
[2] https://www.freedesktop.org/software/systemd/man/os-release.html