### PR TITLE
explorer/init/Linux: use pgrep instead of ps

### DIFF
--- a/cdist/conf/explorer/init
+++ b/cdist/conf/explorer/init
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # 2016 Daniel Heule (hda at sfs.biz)
+# Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
 #
 # This file is part of cdist.
 #
@@ -25,7 +26,10 @@
 uname_s="$(uname -s)"
 
 case "$uname_s" in
-    Linux|FreeBSD)
+    Linux)
+        pgrep -P0 -l | awk '/^1[ \t]/ {print $2;}'
+    ;;
+    FreeBSD)
         ps -o comm= -p 1 || true
     ;;
     *)

--- a/cdist/conf/explorer/init
+++ b/cdist/conf/explorer/init
@@ -27,7 +27,7 @@ uname_s="$(uname -s)"
 
 case "$uname_s" in
     Linux)
-        pgrep -P0 -l | awk '/^1[ \t]/ {print $2;}'
+        (pgrep -P0 -l | awk '/^1[ \t]/ {print $2;}') || true
     ;;
     FreeBSD)
         ps -o comm= -p 1 || true


### PR DESCRIPTION
On some BusyBox-based systems, ps is minimally configured and does not support the -o option.

This commit adds support for these systems by replacing ps with pgrep for Linux systems.

Tested on Debian and LEDE.