### PR TITLE
__user: explore with /etc files

### DIFF
--- a/cdist/conf/type/__user/explorer/group
+++ b/cdist/conf/type/__user/explorer/group
@@ -23,6 +23,10 @@
 
 if [ -f "$__object/parameter/gid" ]; then
    gid=$(cat "$__object/parameter/gid")
-   getent group "$gid" || true
+   if [ -x /usr/bin/getent ] || [ -x /bin/getent ]; then
+      getent group "$gid" || true
+   elif [ -f /etc/group ]; then
+      grep -E "^(${gid}|([^:]:){2}${gid}):" /etc/group || true
+   fi
 fi
 

--- a/cdist/conf/type/__user/explorer/group
+++ b/cdist/conf/type/__user/explorer/group
@@ -26,7 +26,7 @@ if [ -f "$__object/parameter/gid" ]; then
    if [ -x /usr/bin/getent ] || [ -x /bin/getent ]; then
       getent group "$gid" || true
    elif [ -f /etc/group ]; then
-      grep -E "^(${gid}|([^:]:){2}${gid}):" /etc/group || true
+      grep -E "^(${gid}|([^:]+:){2}${gid}):" /etc/group || true
    fi
 fi
 

--- a/cdist/conf/type/__user/explorer/group
+++ b/cdist/conf/type/__user/explorer/group
@@ -23,8 +23,9 @@
 
 if [ -f "$__object/parameter/gid" ]; then
    gid=$(cat "$__object/parameter/gid")
-   if [ -x /usr/bin/getent ] || [ -x /bin/getent ]; then
-      getent group "$gid" || true
+   getent=$(command -v getent)
+   if [ X != X"${getent}" ]; then
+      "${getent}" group "$gid" || true
    elif [ -f /etc/group ]; then
       grep -E "^(${gid}|([^:]+:){2}${gid}):" /etc/group || true
    fi

--- a/cdist/conf/type/__user/explorer/passwd
+++ b/cdist/conf/type/__user/explorer/passwd
@@ -23,8 +23,9 @@
 
 name=$__object_id
 
-if [ -x /usr/bin/getent ] || [ -x /bin/getent ]; then
-  getent passwd "$name" || true
+getent=$(command -v getent)
+if [ X != X"${getent}" ]; then
+  "${getent}" passwd "$name" || true
 elif [ -f /etc/passwd ]; then
   grep "^${name}:" /etc/passwd || true
 fi

--- a/cdist/conf/type/__user/explorer/passwd
+++ b/cdist/conf/type/__user/explorer/passwd
@@ -23,5 +23,8 @@
 
 name=$__object_id
 
-getent passwd "$name" || true
-
+if [ -x /usr/bin/getent ] || [ -x /bin/getent ]; then
+  getent passwd "$name" || true
+elif [ -f /etc/passwd ]; then
+  grep "^${name}:" /etc/passwd || true
+fi

--- a/cdist/conf/type/__user/explorer/shadow
+++ b/cdist/conf/type/__user/explorer/shadow
@@ -31,5 +31,8 @@ case "$os" in
 esac
   
 
-getent "$database" "$name" || true
-
+if [ -x /usr/bin/getent ] || [ -x /bin/getent ]; then
+  getent "$database" "$name" || true
+elif [ -f /etc/shadow ]; then
+  grep "^${name}:" /etc/shadow || true
+fi

--- a/cdist/conf/type/__user/explorer/shadow
+++ b/cdist/conf/type/__user/explorer/shadow
@@ -31,8 +31,9 @@ case "$os" in
 esac
   
 
-if [ -x /usr/bin/getent ] || [ -x /bin/getent ]; then
-  getent "$database" "$name" || true
+getent=$(command -v getent)
+if [ X != X"${getent}" ]; then
+  "${getent}" "$database" "$name" || true
 elif [ -f /etc/shadow ]; then
   grep "^${name}:" /etc/shadow || true
 fi


### PR DESCRIPTION
getent(1) is a utility available where Name Service Switch (NSS)
is available. Many modern operating systems support it, but that
may not be the case of all (e.g. embedded systems).

This commit modifies the __user type explorers to check the
traditional files instead of relying solely on the availability
of getent(1).

- Makes the group explorer use /etc/group
- Makes the passwd explorer use /etc/passwd
- Makes the shadow explorer use /etc/shadow

Implementation note

"getent shadow" does not support querying an entry using a uid
since it does not store that information. Since the shadow explorer
uses __object_id, the passwd explorer does not check if __object_id
matches an entry by uid. This behavior ensures consistent, transparent
behavior of the type. The group explorer, on the other hand, handles
group names and uids; like always.