### PR TITLE
Configfile

### DIFF
--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -3,6 +3,7 @@ import cdist
 import multiprocessing
 import logging
 import collections
+import cdist.configuration
 
 
 # set of beta sub-commands

--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -27,6 +27,17 @@ _verbosity_level = {
     3: logging.DEBUG,
     4: logging.TRACE,
 }
+
+
+# Generate verbosity level constants:
+# VERBOSE_OFF, VERBOSE_ERROR, VERBOSE_WARNING, VERBOSE_INFO, VERBOSE_VERBOSE,
+# VERBOSE_DEBUG, VERBOSE_TRACE.
+this_globals = globals()
+for level in _verbosity_level:
+    const = 'VERBOSE_' + logging.getLevelName(_verbosity_level[level])
+    this_globals[const] = level
+
+
 # All verbosity levels above 4 are TRACE.
 _verbosity_level = collections.defaultdict(
     lambda: logging.TRACE, _verbosity_level)
@@ -87,7 +98,7 @@ def get_parsers():
     parser['loglevel'] = argparse.ArgumentParser(add_help=False)
     parser['loglevel'].add_argument(
             '-q', '--quiet',
-            help='Quiet mode: disables logging, including WARNING and ERROR',
+            help='Quiet mode: disables logging, including WARNING and ERROR.',
             action='store_true', default=False)
     parser['loglevel'].add_argument(
             '-v', '--verbose',
@@ -102,16 +113,15 @@ def get_parsers():
     parser['beta'] = argparse.ArgumentParser(add_help=False)
     parser['beta'].add_argument(
            '-b', '--beta',
-           help=('Enable beta functionality. '
-                 'Can also be enabled using CDIST_BETA env var.'),
+           help=('Enable beta functionality. '),
            action='store_true', dest='beta',
-           default='CDIST_BETA' in os.environ)
+           default=False)
 
     # Main subcommand parser
     parser['main'] = argparse.ArgumentParser(
             description='cdist ' + cdist.VERSION, parents=[parser['loglevel']])
     parser['main'].add_argument(
-            '-V', '--version', help='Show version', action='version',
+            '-V', '--version', help='Show version.', action='version',
             version='%(prog)s ' + cdist.VERSION)
     parser['sub'] = parser['main'].add_subparsers(
             title="Commands", dest="command")
@@ -126,28 +136,33 @@ def get_parsers():
            '-I', '--inventory',
            help=('Use specified custom inventory directory. '
                  'Inventory directory is set up by the following rules: '
-                 'if this argument is set then specified directory is used, '
-                 'if CDIST_INVENTORY_DIR env var is set then its value is '
-                 'used, if HOME env var is set then ~/.cdist/inventory is '
+                 'if cdist configuration resolves this value then specified '
+                 'directory is used, '
+                 'if HOME env var is set then ~/.cdist/inventory is '
                  'used, otherwise distribution inventory directory is used.'),
            dest="inventory_dir", required=False)
+
+    parser['common'] = argparse.ArgumentParser(add_help=False)
+    parser['common'].add_argument(
+           '-g', '--config-file',
+           help=('Use specified custom configuration file.'),
+           dest="config_file", required=False)
 
     # Config
     parser['config_main'] = argparse.ArgumentParser(add_help=False)
     parser['config_main'].add_argument(
             '-C', '--cache-path-pattern',
-            help=('Specify custom cache path pattern. It can also be set '
-                  'by CDIST_CACHE_PATH_PATTERN environment variable. If '
+            help=('Specify custom cache path pattern. If '
                   'it is not set then default hostdir is used.'),
             dest='cache_path_pattern',
-            default=os.environ.get('CDIST_CACHE_PATH_PATTERN'))
+            default=None)
     parser['config_main'].add_argument(
             '-c', '--conf-dir',
             help=('Add configuration directory (can be repeated, '
-                  'last one wins)'), action='append')
+                  'last one wins).'), action='append')
     parser['config_main'].add_argument(
            '-i', '--initial-manifest',
-           help='path to a cdist manifest or \'-\' to read from stdin.',
+           help='Path to a cdist manifest or \'-\' to read from stdin.',
            dest='manifest', required=False)
     parser['config_main'].add_argument(
            '-j', '--jobs', nargs='?',
@@ -160,17 +175,18 @@ def get_parsers():
            const=multiprocessing.cpu_count())
     parser['config_main'].add_argument(
            '-n', '--dry-run',
-           help='do not execute code', action='store_true')
+           help='Do not execute code.', action='store_true')
     parser['config_main'].add_argument(
            '-o', '--out-dir',
-           help='directory to save cdist output in', dest="out_path")
+           help='Directory to save cdist output in.', dest="out_path")
     parser['config_main'].add_argument(
            '-R', '--use-archiving', nargs='?',
            choices=('tar', 'tgz', 'tbz2', 'txz',),
            help=('Operate by using archiving with compression where '
                  'apropriate. Supported values are: tar - tar archive, '
                  'tgz - gzip tar archive (the default), '
-                 'tbz2 - bzip2 tar archive and txz - lzma tar archive.'),
+                 'tbz2 - bzip2 tar archive and txz - lzma tar archive. '
+                 'Currently in beta.'),
            action='store', dest='use_archiving',
            const='tgz')
 
@@ -179,33 +195,33 @@ def get_parsers():
     # parsing to determine implementation default
     parser['config_main'].add_argument(
            '-r', '--remote-out-dir',
-           help='Directory to save cdist output in on the target host',
+           help='Directory to save cdist output in on the target host.',
            dest="remote_out_path")
     parser['config_main'].add_argument(
            '--remote-copy',
-           help='Command to use for remote copy (should behave like scp)',
+           help='Command to use for remote copy (should behave like scp).',
            action='store', dest='remote_copy',
-           default=os.environ.get('CDIST_REMOTE_COPY'))
+           default=None)
     parser['config_main'].add_argument(
            '--remote-exec',
            help=('Command to use for remote execution '
-                 '(should behave like ssh)'),
+                 '(should behave like ssh).'),
            action='store', dest='remote_exec',
-           default=os.environ.get('CDIST_REMOTE_EXEC'))
+           default=None)
 
     # Config
     parser['config_args'] = argparse.ArgumentParser(add_help=False)
     parser['config_args'].add_argument(
              '-A', '--all-tagged',
-             help=('use all hosts present in tags db'),
+             help=('Use all hosts present in tags db. Currently in beta.'),
              action="store_true", dest="all_tagged_hosts", default=False)
     parser['config_args'].add_argument(
              '-a', '--all',
-             help=('list hosts that have all specified tags, '
-                   'if -t/--tag is specified'),
+             help=('List hosts that have all specified tags, '
+                   'if -t/--tag is specified.'),
              action="store_true", dest="has_all_tags", default=False)
     parser['config_args'].add_argument(
-            'host', nargs='*', help='host(s) to operate on')
+            'host', nargs='*', help='Host(s) to operate on.')
     parser['config_args'].add_argument(
             '-f', '--file',
             help=('Read specified file for a list of additional hosts to '
@@ -223,15 +239,17 @@ def get_parsers():
            const=multiprocessing.cpu_count())
     parser['config_args'].add_argument(
            '-s', '--sequential',
-           help='operate on multiple hosts sequentially (default)',
+           help='Operate on multiple hosts sequentially (default).',
            action='store_const', dest='parallel', const=0)
     parser['config_args'].add_argument(
              '-t', '--tag',
-             help=('host is specified by tag, not hostname/address; '
-                   'list all hosts that contain any of specified tags'),
+             help=('Host is specified by tag, not hostname/address; '
+                   'list all hosts that contain any of specified tags. '
+                   'Currently in beta.'),
              dest='tag', required=False, action="store_true", default=False)
     parser['config'] = parser['sub'].add_parser(
             'config', parents=[parser['loglevel'], parser['beta'],
+                               parser['common'],
                                parser['config_main'],
                                parser['inventory_common'],
                                parser['config_args']])
@@ -245,15 +263,17 @@ def get_parsers():
     # Inventory
     parser['inventory'] = parser['sub'].add_parser(
            'inventory', parents=[parser['loglevel'], parser['beta'],
+                                 parser['common'],
                                  parser['inventory_common']])
     parser['invsub'] = parser['inventory'].add_subparsers(
             title="Inventory commands", dest="subcommand")
 
     parser['add-host'] = parser['invsub'].add_parser(
             'add-host', parents=[parser['loglevel'], parser['beta'],
+                                 parser['common'],
                                  parser['inventory_common']])
     parser['add-host'].add_argument(
-            'host', nargs='*', help='host(s) to add')
+            'host', nargs='*', help='Host(s) to add.')
     parser['add-host'].add_argument(
            '-f', '--file',
            help=('Read additional hosts to add from specified file '
@@ -264,10 +284,11 @@ def get_parsers():
 
     parser['add-tag'] = parser['invsub'].add_parser(
             'add-tag', parents=[parser['loglevel'], parser['beta'],
+                                parser['common'],
                                 parser['inventory_common']])
     parser['add-tag'].add_argument(
            'host', nargs='*',
-           help='list of host(s) for which tags are added')
+           help='List of host(s) for which tags are added.')
     parser['add-tag'].add_argument(
            '-f', '--file',
            help=('Read additional hosts to add tags from specified file '
@@ -289,16 +310,17 @@ def get_parsers():
     parser['add-tag'].add_argument(
            '-t', '--taglist',
            help=("Tag list to be added for specified host(s), comma separated"
-                 " values"),
+                 " values."),
            dest="taglist", required=False)
 
     parser['del-host'] = parser['invsub'].add_parser(
             'del-host', parents=[parser['loglevel'], parser['beta'],
+                                 parser['common'],
                                  parser['inventory_common']])
     parser['del-host'].add_argument(
-            'host', nargs='*', help='host(s) to delete')
+            'host', nargs='*', help='Host(s) to delete.')
     parser['del-host'].add_argument(
-            '-a', '--all', help=('Delete all hosts'),
+            '-a', '--all', help=('Delete all hosts.'),
             dest='all', required=False, action="store_true", default=False)
     parser['del-host'].add_argument(
             '-f', '--file',
@@ -310,13 +332,14 @@ def get_parsers():
 
     parser['del-tag'] = parser['invsub'].add_parser(
             'del-tag', parents=[parser['loglevel'], parser['beta'],
+                                parser['common'],
                                 parser['inventory_common']])
     parser['del-tag'].add_argument(
             'host', nargs='*',
-            help='list of host(s) for which tags are deleted')
+            help='List of host(s) for which tags are deleted.')
     parser['del-tag'].add_argument(
             '-a', '--all',
-            help=('Delete all tags for specified host(s)'),
+            help=('Delete all tags for specified host(s).'),
             dest='all', required=False, action="store_true", default=False)
     parser['del-tag'].add_argument(
             '-f', '--file',
@@ -339,18 +362,19 @@ def get_parsers():
     parser['del-tag'].add_argument(
             '-t', '--taglist',
             help=("Tag list to be deleted for specified host(s), "
-                  "comma separated values"),
+                  "comma separated values."),
             dest="taglist", required=False)
 
     parser['list'] = parser['invsub'].add_parser(
             'list', parents=[parser['loglevel'], parser['beta'],
+                             parser['common'],
                              parser['inventory_common']])
     parser['list'].add_argument(
-            'host', nargs='*', help='host(s) to list')
+            'host', nargs='*', help='Host(s) to list.')
     parser['list'].add_argument(
             '-a', '--all',
-            help=('list hosts that have all specified tags, '
-                  'if -t/--tag is specified'),
+            help=('List hosts that have all specified tags, '
+                  'if -t/--tag is specified.'),
             action="store_true", dest="has_all_tags", default=False)
     parser['list'].add_argument(
             '-f', '--file',
@@ -359,12 +383,12 @@ def get_parsers():
                   'If no host or host file is specified then, by default, '
                   'list all.'), dest='hostfile', required=False)
     parser['list'].add_argument(
-            '-H', '--host-only', help=('Suppress tags listing'),
+            '-H', '--host-only', help=('Suppress tags listing.'),
             action="store_true", dest="list_only_host", default=False)
     parser['list'].add_argument(
             '-t', '--tag',
-            help=('host is specified by tag, not hostname/address; '
-                  'list all hosts that contain any of specified tags'),
+            help=('Host is specified by tag, not hostname/address; '
+                  'list all hosts that contain any of specified tags.'),
             action="store_true", default=False)
 
     parser['inventory'].set_defaults(

--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -1,7 +1,6 @@
 import argparse
 import cdist
 import multiprocessing
-import os
 import logging
 import collections
 
@@ -414,3 +413,23 @@ def handle_loglevel(args):
         args.verbose = _verbosity_level_off
 
     logging.root.setLevel(_verbosity_level[args.verbose])
+
+
+def parse_and_configure(argv):
+    parser = get_parsers()
+    parser_args = parser['main'].parse_args(argv)
+    cfg = cdist.configuration.Configuration(parser_args)
+    args = cfg.get_args()
+    # Loglevels are handled globally in here
+    handle_loglevel(args)
+
+    log = logging.getLogger("cdist")
+
+    log.verbose("version %s" % cdist.VERSION)
+    log.trace('command line args: {}'.format(cfg.command_line_args))
+    log.trace('configuration: {}'.format(cfg.get_config()))
+    log.trace('configured args: {}'.format(args))
+
+    check_beta(vars(args))
+
+    return parser, cfg

--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -115,7 +115,7 @@ def get_parsers():
            '-b', '--beta',
            help=('Enable beta functionality. '),
            action='store_true', dest='beta',
-           default='CDIST_BETA' in os.environ)
+           default=False)
 
     # Main subcommand parser
     parser['main'] = argparse.ArgumentParser(
@@ -155,7 +155,7 @@ def get_parsers():
             help=('Specify custom cache path pattern. If '
                   'it is not set then default hostdir is used.'),
             dest='cache_path_pattern',
-            default=os.environ.get('CDIST_CACHE_PATH_PATTERN'))
+            default=None)
     parser['config_main'].add_argument(
             '-c', '--conf-dir',
             help=('Add configuration directory (can be repeated, '
@@ -201,13 +201,13 @@ def get_parsers():
            '--remote-copy',
            help='Command to use for remote copy (should behave like scp).',
            action='store', dest='remote_copy',
-           default=os.environ.get('CDIST_REMOTE_COPY'))
+           default=None)
     parser['config_main'].add_argument(
            '--remote-exec',
            help=('Command to use for remote execution '
                  '(should behave like ssh).'),
            action='store', dest='remote_exec',
-           default=os.environ.get('CDIST_REMOTE_EXEC'))
+           default=None)
 
     # Config
     parser['config_args'] = argparse.ArgumentParser(add_help=False)

--- a/cdist/configuration.py
+++ b/cdist/configuration.py
@@ -234,6 +234,12 @@ class Configuration(metaclass=Singleton):
     _global_config_file = os.path.join('/', 'etc', _config_basename, )
     _local_config_file = os.path.join(os.path.expanduser('~'),
                                       '.' + _config_basename, )
+    if (not (os.path.exists(_local_config_file) and
+             os.path.isfile(_local_config_file))):
+        _local_config_file = os.path.join(
+            os.environ.get('XDG_CONFIG_HOME',
+                           os.path.expanduser('~/.config/cdist')),
+            _config_basename)
     default_config_files = (_global_config_file, _local_config_file, )
     ENV_VAR_CONFIG_FILE = 'CDIST_CONFIG_FILE'
 

--- a/cdist/configuration.py
+++ b/cdist/configuration.py
@@ -230,10 +230,11 @@ _ARG_OPTION_MAPPING = {
 
 
 class Configuration(metaclass=Singleton):
-    global_config_file = os.path.join('/', 'etc', 'cdist.cfg', )
-    local_config_file = os.path.join(os.path.expanduser('~'),
-                                     '.cdist.cfg', )
-    default_config_files = (global_config_file, local_config_file, )
+    _config_basename = 'cdist.cfg'
+    _global_config_file = os.path.join('/', 'etc', _config_basename, )
+    _local_config_file = os.path.join(os.path.expanduser('~'),
+                                      '.' + _config_basename, )
+    default_config_files = (_global_config_file, _local_config_file, )
     ENV_VAR_CONFIG_FILE = 'CDIST_CONFIG_FILE'
 
     VERBOSITY_VALUES = _VERBOSITY_VALUES

--- a/cdist/configuration.py
+++ b/cdist/configuration.py
@@ -198,7 +198,7 @@ class DelimitedValuesOption(OptionBase):
 
 class ConfDirOption(DelimitedValuesOption):
     def __init__(self):
-        super().__init__('conf_dir', ':')
+        super().__init__('conf_dir', os.pathsep)
 
 
 class ArchivingOption(SelectOption):

--- a/cdist/configuration.py
+++ b/cdist/configuration.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+#
+# 2017 Darko Poljak (darko.poljak at gmail.com)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+
+import configparser
+import os
+import cdist
+import functools
+import cdist.argparse
+import re
+
+
+class Singleton(type):
+    instance = None
+
+    def __call__(cls, *args, **kwargs):
+        if not cls.instance:
+            cls.instance = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls.instance
+
+
+def _convert_option_select(val, option, valid_values):
+    if val in valid_values:
+        return val
+    else:
+        raise ValueError("Invalid {} value: {}.".format(option, val))
+
+
+def _convert_conf_dir(val):
+    vals = re.split(r'(?<!\\):', val)
+    vals = [x for x in vals if x]
+    if vals:
+        return vals
+    else:
+        return None
+
+
+def _convert_verbosity(val):
+    val = _convert_option_select(
+        val, 'verbosity', Configuration.VERBOSITY_VALUES)
+    if val == 'QUIET':
+        return cdist.argparse.VERBOSE_OFF
+    else:
+        name = 'VERBOSE_' + val
+        verbose = getattr(cdist.argparse, name)
+        return verbose
+
+
+def _convert_archiving(val):
+    val = _convert_option_select(
+        val, 'archiving', Configuration.ARCHIVING_VALUES)
+    if val == 'none':
+        return None
+    else:
+        return val
+
+
+class Configuration(metaclass=Singleton):
+    global_config_file = os.path.join('/', 'etc', 'cdist.cfg', )
+    local_config_file = os.path.join(os.path.expanduser('~'),
+                                     '.cdist', 'cdist.cfg', )
+    default_config_files = (global_config_file, local_config_file, )
+
+    VERBOSITY_VALUES = (
+        'ERROR', 'WARNING', 'INFO', 'VERBOSE', 'DEBUG', 'TRACE', 'QUIET',
+    )
+    ARCHIVING_VALUES = (
+        'tar', 'tgz', 'tbz2', 'txz', 'none',
+    )
+
+    CONFIG_FILE_OPTIONS = {
+        'GLOBAL': {
+            'beta': 'boolean',
+            'local_shell': str,
+            'remote_shell': str,
+            'cache_path_pattern': str,
+            'conf_dir': _convert_conf_dir,
+            'init_manifest': str,
+            'out_path': str,
+            'remote_out_path': str,
+            'remote_copy': str,
+            'remote_exec': str,
+            'inventory_dir': str,
+            'jobs': int,
+            'parallel': int,
+            'verbosity': _convert_verbosity,
+            'archiving': _convert_archiving,
+        },
+    }
+
+    ENV_VAR_OPTION_MAPPING = {
+        'CDIST_BETA': 'beta',
+        'CDIST_PATH': 'conf_dir',
+        'CDIST_LOCAL_SHELL': 'local_shell',
+        'CDIST_REMOTE_SHELL': 'remote_shell',
+        'CDIST_REMOTE_EXEC': 'remote_exec',
+        'CDIST_REMOTE_COPY': 'remote_copy',
+        'CDIST_INVENTORY_DIR': 'inventory_dir',
+        'CDIST_CACHE_PATH_PATTERN': 'cache_path_pattern',
+    }
+    BOOL_ENV_VAR_OPTIONS = ('CDIST_BETA', )
+    ARG_OPTION_MAPPING = {
+        'beta': 'beta',
+        'cache_path_pattern': 'cache_path_pattern',
+        'conf_dir': 'conf_dir',
+        'manifest': 'init_manifest',
+        'out_path': 'out_path',
+        'remote_out_path': 'remote_out_path',
+        'remote_copy': 'remote_copy',
+        'remote_exec': 'remote_exec',
+        'inventory_dir': 'inventory_dir',
+        'jobs': 'jobs',
+        'parallel': 'parallel',
+        'verbose': 'verbosity',
+        'use_archiving': 'archiving',
+    }
+    ADJUST_ARG_OPTION_MAPPING = {
+        'beta': 'beta',
+        'cache_path_pattern': 'cache_path_pattern',
+        'conf_dir': 'conf_dir',
+        'init_manifest': 'manifest',
+        'out_path': 'out_path',
+        'remote_out_path': 'remote_out_path',
+        'remote_copy': 'remote_copy',
+        'remote_exec': 'remote_exec',
+        'inventory_dir': 'inventory_dir',
+        'jobs': 'jobs',
+        'parallel': 'parallel',
+        'verbosity': 'verbose',
+        'archiving': 'use_archiving',
+    }
+
+    def _convert_args(self, args):
+        if args:
+            if hasattr(args, '__dict__'):
+                return vars(args)
+            else:
+                raise ValueError(
+                    'args parameter must be have __dict__ attribute')
+        else:
+            return None
+
+    def __init__(self, args, env=os.environ,
+                 config_files=default_config_files):
+        self.args = self._convert_args(args)
+        self.env = env
+        self.config_files = config_files
+        self.config = self._get_config()
+
+    def get_config(self, section=None):
+        if section is None:
+            return self.config
+        if section in self.config:
+            return self.config[section]
+        raise ValueError('Unknown section: {}'.format(section))
+
+    def adjust_args(self, args, section='GLOBAL'):
+        args_dict = self._convert_args(args)
+        cfg = self.get_config(section)
+        for option in self.ADJUST_ARG_OPTION_MAPPING:
+            if option in cfg:
+                arg_opt = self.ADJUST_ARG_OPTION_MAPPING[option]
+                if option == 'verbosity' and cfg[option] == 'QUIET':
+                    setattr(args, 'quiet', True)
+                else:
+                    setattr(args, arg_opt, cfg[option])
+
+    def _convert_value(self, val, option, converter):
+        try:
+            newval = converter(val)
+        except:
+            raise ValueError("Invalid {} value: {}.".format(option, val))
+        if not isinstance(newval, str) or newval:
+            return newval
+        else:
+            return None
+
+    def _read_config_file(self, files):
+        config_parser = configparser.ConfigParser()
+        config_parser.read(files)
+        d = dict()
+        for section in config_parser.sections():
+            if section not in self.CONFIG_FILE_OPTIONS:
+                raise ValueError("Invalid section: {}.".format(section))
+            if section not in d:
+                d[section] = dict()
+            for option in config_parser[section]:
+                if option not in self.CONFIG_FILE_OPTIONS[section]:
+                    raise ValueError("Invalid option: {}.".format(option))
+                converter = self.CONFIG_FILE_OPTIONS[section][option]
+                if converter == 'boolean':
+                    newval = config_parser.getboolean(section, option)
+                else:
+                    val = config_parser[section][option]
+                    newval = self._convert_value(val, option, converter)
+                d[section][option] = newval
+        return d
+
+    def _read_env_var_config(self, env):
+        d = dict()
+        for option in self.ENV_VAR_OPTION_MAPPING:
+            if option in env:
+                dst_option = self.ENV_VAR_OPTION_MAPPING[option]
+                if option in self.BOOL_ENV_VAR_OPTIONS:
+                    d[dst_option] = True
+                elif dst_option == 'conf_dir':
+                    d[dst_option] = _convert_conf_dir(env[option])
+                else:
+                    d[dst_option] = env[option]
+        return d
+
+    def _read_args_config(self, args):
+        d = dict()
+        for option in self.ARG_OPTION_MAPPING:
+            if option in args:
+                dst_option = self.ARG_OPTION_MAPPING[option]
+                d[dst_option] = args[option]
+        return d
+
+    def _update_config_dict(self, config, newconfig):
+        for section in newconfig:
+            self._update_config_dict_section(
+                section, config, newconfig[section])
+
+    def _update_config_dict_section(self, section, config, newconfig):
+        if section not in config:
+            config[section] = dict()
+        for option in newconfig:
+            val = newconfig[option]
+            if option == 'conf_dir':
+                newval = []
+                if option in config[section] and config[section][option]:
+                    newval.extend(config[section][option])
+                if newconfig[option]:
+                    newval.extend(newconfig[option])
+            else:
+                newval = val
+            config[section][option] = newval
+
+    def _translate_values(self, config):
+        for section in config:
+            x = config[section]
+            for option in x:
+                if option in ('jobs', 'parallel', ):
+                    if x[option] == -1:
+                        import multiprocessing
+                        x[option] = multiprocessing.cpu_count()
+
+    def _get_config(self):
+        # global config file
+        # local config file
+        config = self._read_config_file(self.config_files)
+        # default empty config if needed
+        if not config:
+            config['GLOBAL'] = dict()
+        # environment variable
+        newconfig = self._read_env_var_config(self.env)
+        for section in config:
+            self._update_config_dict_section(section, config, newconfig)
+        # command line config file
+        if (self.args and 'config_file' in self.args and
+                self.args['config_file']):
+            newconfig = self._read_config_file(self.args['config_file'])
+            self._update_config_dict(config, newconfig)
+        # command line
+        if self.args:
+            newconfig = self._read_args_config(self.args)
+            for section in config:
+                self._update_config_dict_section(section, config, newconfig)
+        self._translate_values(config)
+        return config

--- a/cdist/exec/local.py
+++ b/cdist/exec/local.py
@@ -56,7 +56,7 @@ class Local(object):
                  add_conf_dirs=None,
                  cache_path_pattern=None,
                  quiet_mode=False,
-                 configuration={}):
+                 configuration=None):
 
         self.target_host = target_host
         if target_host_tags is None:
@@ -71,7 +71,10 @@ class Local(object):
         self._add_conf_dirs = add_conf_dirs
         self.cache_path_pattern = cache_path_pattern
         self.quiet_mode = quiet_mode
-        self.configuration = configuration
+        if configuration:
+            self.configuration = configuration
+        else:
+            self.configuration = {}
 
         self._init_log()
         self._init_permissions()

--- a/cdist/exec/remote.py
+++ b/cdist/exec/remote.py
@@ -64,7 +64,8 @@ class Remote(object):
                  remote_copy,
                  base_path=None,
                  quiet_mode=None,
-                 archiving_mode=None):
+                 archiving_mode=None,
+                 configuration={}):
         self.target_host = target_host
         self._exec = remote_exec
         self._copy = remote_copy
@@ -75,6 +76,7 @@ class Remote(object):
             self.base_path = "/var/lib/cdist"
         self.quiet_mode = quiet_mode
         self.archiving_mode = archiving_mode
+        self.configuration = configuration
 
         self.conf_path = os.path.join(self.base_path, "conf")
         self.object_path = os.path.join(self.base_path, "object")
@@ -237,7 +239,10 @@ class Remote(object):
 
         """
 
-        command = [os.environ.get('CDIST_REMOTE_SHELL', "/bin/sh"), "-e"]
+        command = [
+            self.configuration.get('CDIST_REMOTE_SHELL', "/bin/sh"),
+            "-e"
+        ]
         command.append(script)
 
         return self.run(command, env, return_output)

--- a/cdist/exec/remote.py
+++ b/cdist/exec/remote.py
@@ -63,7 +63,7 @@ class Remote(object):
                  base_path=None,
                  quiet_mode=None,
                  archiving_mode=None,
-                 configuration={}):
+                 configuration=None):
         self.target_host = target_host
         self._exec = remote_exec
         self._copy = remote_copy
@@ -74,7 +74,10 @@ class Remote(object):
             self.base_path = "/var/lib/cdist"
         self.quiet_mode = quiet_mode
         self.archiving_mode = archiving_mode
-        self.configuration = configuration
+        if configuration:
+            self.configuration = configuration
+        else:
+            self.configuration = {}
 
         self.conf_path = os.path.join(self.base_path, "conf")
         self.object_path = os.path.join(self.base_path, "object")

--- a/cdist/inventory.py
+++ b/cdist/inventory.py
@@ -26,6 +26,7 @@ import os
 import os.path
 import itertools
 import sys
+import cdist.configuration
 from cdist.hostsource import hostfile_process_line
 
 DIST_INVENTORY_DB_NAME = "inventory"
@@ -34,21 +35,23 @@ dist_inventory_db = os.path.abspath(os.path.join(
     os.path.dirname(cdist.__file__), DIST_INVENTORY_DB_NAME))
 
 
-def determine_default_inventory_dir(args):
+def determine_default_inventory_dir(args, configuration):
     # The order of inventory dir setting by decreasing priority
-    # 1. inventory_dir argument
-    # 2. CDIST_INVENTORY_DIR env var if set
-    # 3. ~/.cdist/inventory if HOME env var is set
-    # 4. distribution inventory directory
-    if not args.inventory_dir:
-        if 'CDIST_INVENTORY_DIR' in os.environ:
-            args.inventory_dir = os.environ['CDIST_INVENTORY_DIR']
+    # 1. inventory_dir from configuration
+    # 2. ~/.cdist/inventory if HOME env var is set
+    # 3. distribution inventory directory
+    inventory_dir_set = False
+    if 'inventory_dir' in configuration:
+        val = configuration['inventory_dir']
+        if val:
+            args.inventory_dir = val
+            inventory_dir_set = True
+    if not inventory_dir_set:
+        home = cdist.home_dir()
+        if home:
+            args.inventory_dir = os.path.join(home, DIST_INVENTORY_DB_NAME)
         else:
-            home = cdist.home_dir()
-            if home:
-                args.inventory_dir = os.path.join(home, DIST_INVENTORY_DB_NAME)
-            else:
-                args.inventory_dir = dist_inventory_db
+            args.inventory_dir = dist_inventory_db
 
 
 def contains_all(big, little):
@@ -80,8 +83,9 @@ def rstrip_nl(s):
 class Inventory(object):
     """Inventory main class"""
 
-    def __init__(self, db_basedir=dist_inventory_db):
+    def __init__(self, db_basedir=dist_inventory_db, configuration={}):
         self.db_basedir = db_basedir
+        self.configuration = configuration
         self.log = logging.getLogger("inventory")
         self.init_db()
 
@@ -171,7 +175,10 @@ class Inventory(object):
         log = logging.getLogger("inventory")
         if 'taglist' in args:
             args.taglist = cls.strlist_to_list(args.taglist)
-        determine_default_inventory_dir(args)
+
+        cfg = cdist.configuration.Configuration(args)
+        configuration = cfg.get_config(section='GLOBAL')
+        determine_default_inventory_dir(args, configuration)
 
         log.debug("Using inventory: {}".format(args.inventory_dir))
         log.trace("Inventory args: {}".format(vars(args)))
@@ -182,23 +189,26 @@ class Inventory(object):
                               hostfile=args.hostfile,
                               db_basedir=args.inventory_dir,
                               list_only_host=args.list_only_host,
-                              has_all_tags=args.has_all_tags)
+                              has_all_tags=args.has_all_tags,
+                              configuration=configuration)
         elif args.subcommand == "add-host":
             c = InventoryHost(hosts=args.host, hostfile=args.hostfile,
-                              db_basedir=args.inventory_dir)
+                              db_basedir=args.inventory_dir,
+                              configuration=configuration)
         elif args.subcommand == "del-host":
             c = InventoryHost(hosts=args.host, hostfile=args.hostfile,
                               all=args.all, db_basedir=args.inventory_dir,
-                              action="del")
+                              action="del", configuration=configuration)
         elif args.subcommand == "add-tag":
             c = InventoryTag(hosts=args.host, tags=args.taglist,
                              hostfile=args.hostfile, tagfile=args.tagfile,
-                             db_basedir=args.inventory_dir)
+                             db_basedir=args.inventory_dir,
+                             configuration=configuration)
         elif args.subcommand == "del-tag":
             c = InventoryTag(hosts=args.host, tags=args.taglist,
                              hostfile=args.hostfile, tagfile=args.tagfile,
                              all=args.all, db_basedir=args.inventory_dir,
-                             action="del")
+                             action="del", configuration=configuration)
         else:
             raise cdist.Error("Unknown inventory command \'{}\'".format(
                         args.subcommand))
@@ -208,8 +218,8 @@ class Inventory(object):
 class InventoryList(Inventory):
     def __init__(self, hosts=None, istag=False, hostfile=None,
                  list_only_host=False, has_all_tags=False,
-                 db_basedir=dist_inventory_db):
-        super().__init__(db_basedir)
+                 db_basedir=dist_inventory_db, configuration={}):
+        super().__init__(db_basedir, configuration)
         self.hosts = hosts
         self.istag = istag
         self.hostfile = hostfile
@@ -274,8 +284,9 @@ class InventoryList(Inventory):
 
 class InventoryHost(Inventory):
     def __init__(self, hosts=None, hostfile=None,
-                 db_basedir=dist_inventory_db, all=False, action="add"):
-        super().__init__(db_basedir)
+                 db_basedir=dist_inventory_db, all=False, action="add",
+                 configuration={}):
+        super().__init__(db_basedir, configuration)
         self.actions = ("add", "del")
         if action not in self.actions:
             raise cdist.Error("Invalid action \'{}\', valid actions are:"
@@ -323,8 +334,9 @@ class InventoryHost(Inventory):
 
 class InventoryTag(Inventory):
     def __init__(self, hosts=None, tags=None, hostfile=None, tagfile=None,
-                 db_basedir=dist_inventory_db, all=False, action="add"):
-        super().__init__(db_basedir)
+                 db_basedir=dist_inventory_db, all=False, action="add",
+                 configuration={}):
+        super().__init__(db_basedir, configuration)
         self.actions = ("add", "del")
         if action not in self.actions:
             raise cdist.Error("Invalid action \'{}\', valid actions are:"

--- a/cdist/inventory.py
+++ b/cdist/inventory.py
@@ -83,9 +83,12 @@ def rstrip_nl(s):
 class Inventory(object):
     """Inventory main class"""
 
-    def __init__(self, db_basedir=dist_inventory_db, configuration={}):
+    def __init__(self, db_basedir=dist_inventory_db, configuration=None):
         self.db_basedir = db_basedir
-        self.configuration = configuration
+        if configuration:
+            self.configuration = configuration
+        else:
+            self.configuration = {}
         self.log = logging.getLogger("inventory")
         self.init_db()
 
@@ -218,7 +221,7 @@ class Inventory(object):
 class InventoryList(Inventory):
     def __init__(self, hosts=None, istag=False, hostfile=None,
                  list_only_host=False, has_all_tags=False,
-                 db_basedir=dist_inventory_db, configuration={}):
+                 db_basedir=dist_inventory_db, configuration=None):
         super().__init__(db_basedir, configuration)
         self.hosts = hosts
         self.istag = istag
@@ -285,7 +288,7 @@ class InventoryList(Inventory):
 class InventoryHost(Inventory):
     def __init__(self, hosts=None, hostfile=None,
                  db_basedir=dist_inventory_db, all=False, action="add",
-                 configuration={}):
+                 configuration=None):
         super().__init__(db_basedir, configuration)
         self.actions = ("add", "del")
         if action not in self.actions:
@@ -335,7 +338,7 @@ class InventoryHost(Inventory):
 class InventoryTag(Inventory):
     def __init__(self, hosts=None, tags=None, hostfile=None, tagfile=None,
                  db_basedir=dist_inventory_db, all=False, action="add",
-                 configuration={}):
+                 configuration=None):
         super().__init__(db_basedir, configuration)
         self.actions = ("add", "del")
         if action not in self.actions:

--- a/cdist/test/configuration/__init__.py
+++ b/cdist/test/configuration/__init__.py
@@ -275,7 +275,7 @@ class ConfigurationTestCase(test.CdistTestCase):
         configuration._translate_values(d)
         self.assertEqual(d, expected)
 
-    def test_get_and_adjust_config(self):
+    def test_get_config_and_configured_args(self):
         args = argparse.Namespace()
         args.jobs = 8
         args.dry_run = True
@@ -313,7 +313,7 @@ class ConfigurationTestCase(test.CdistTestCase):
 
         args = argparse.Namespace()
         self.assertEqual(vars(args), {})
-        configuration.adjust_args(args)
+        args = configuration.get_args()
         dargs = vars(args)
         expected_args = {
             'beta': True,
@@ -329,6 +329,8 @@ class ConfigurationTestCase(test.CdistTestCase):
             'parallel': 4,
             'verbose': cap.VERBOSE_INFO,
             'use_archiving': 'txz',
+            'dry_run': True,
+            'config_file': self.custom_config_file,
         }
 
         self.assertEqual(dargs, expected_args)

--- a/cdist/test/configuration/__init__.py
+++ b/cdist/test/configuration/__init__.py
@@ -1,0 +1,340 @@
+# -*- coding: utf-8 -*-
+#
+# 2017 Darko Poljak (darko.poljak at gmail.com)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+import configparser
+import os
+import cdist.configuration as cc
+import os.path as op
+import argparse
+from cdist import test
+import cdist.argparse as cap
+
+
+my_dir = op.abspath(op.dirname(__file__))
+fixtures = op.join(my_dir, 'fixtures')
+
+
+class ConfigurationTestCase(test.CdistTestCase):
+
+    def setUp(self):
+        # Create test config file.
+        config = configparser.ConfigParser()
+        config['GLOBAL'] = {
+            'beta': 'off',
+            'local_shell': '/bin/sh',
+            'remote_shell': '/bin/sh',
+            'inventory_dir': '',
+            'cache_path_pattern': '',
+            'conf_dir': '',
+            'init_manifest': '',
+            'out_path': '',
+            'remote_out_path': '',
+            'remote_copy': '',
+            'remote_exec': '',
+            'jobs': '0',
+            'parallel': '-1',
+            'verbosity': 'INFO',
+            'archiving': 'none',
+        }
+        config_custom = configparser.ConfigParser()
+        config_custom['GLOBAL'] = {
+            'parallel': '4',
+            'archiving': 'txz',
+        }
+
+        self.expected_config_dict = {
+            'GLOBAL': {
+                'beta': False,
+                'local_shell': '/bin/sh',
+                'remote_shell': '/bin/sh',
+                'inventory_dir': None,
+                'cache_path_pattern': None,
+                'conf_dir': None,
+                'init_manifest': None,
+                'out_path': None,
+                'remote_out_path': None,
+                'remote_copy': None,
+                'remote_exec': None,
+                'jobs': 0,
+                'parallel': -1,
+                'verbosity': cap.VERBOSE_INFO,
+                'archiving': None,
+            },
+        }
+
+        self.config_file = os.path.join(fixtures, 'cdist.cfg')
+        with open(self.config_file, 'w') as f:
+            config.write(f)
+
+        self.custom_config_file = os.path.join(fixtures, 'cdist_custom.cfg')
+        with open(self.custom_config_file, 'w') as f:
+            config_custom.write(f)
+
+        config['TEST'] = {}
+        self.invalid_config_file1 = os.path.join(fixtures,
+                                                 'cdist_invalid1.cfg')
+        with open(self.invalid_config_file1, 'w') as f:
+            config.write(f)
+
+        del config['TEST']
+        config['GLOBAL']['test'] = 'test'
+        self.invalid_config_file2 = os.path.join(fixtures,
+                                                 'cdist_invalid2.cfg')
+        with open(self.invalid_config_file2, 'w') as f:
+            config.write(f)
+
+        del config['GLOBAL']['test']
+        config['GLOBAL']['archiving'] = 'zip'
+        self.invalid_config_file3 = os.path.join(fixtures,
+                                                 'cdist_invalid3.cfg')
+        with open(self.invalid_config_file3, 'w') as f:
+            config.write(f)
+
+        self.maxDiff = None
+
+    def tearDown(self):
+        os.remove(self.config_file)
+        os.remove(self.custom_config_file)
+        os.remove(self.invalid_config_file1)
+        os.remove(self.invalid_config_file2)
+        os.remove(self.invalid_config_file3)
+
+    def test_singleton(self):
+        x = cc.Configuration(None)
+        args = argparse.Namespace()
+        args.a = 'a'
+        y = cc.Configuration()
+        self.assertIs(x, y)
+
+    def test_convert_option_select(self):
+        valid_values = ('spam', 'eggs', )
+        val = 'spam'
+        rv = cc._convert_option_select(val, 'test', valid_values)
+        self.assertEqual(val, rv)
+        val = 'spamandeggs'
+        with self.assertRaises(ValueError):
+            cc._convert_option_select(val, 'test', valid_values)
+
+    def test_convert_conf_dir(self):
+        val = '/usr/local/cdist:~/.cdist:~/dot-cdist'
+        expected = ['/usr/local/cdist', '~/.cdist', '~/dot-cdist', ]
+        rv = cc._convert_conf_dir(val)
+        self.assertEqual(rv, expected)
+
+    def test_convert_verbosity(self):
+        for val in cc.Configuration.VERBOSITY_VALUES:
+            if val == 'QUIET':
+                expected = cap.VERBOSE_OFF
+            else:
+                expected = getattr(cap, 'VERBOSE_' + val)
+            rv = cc._convert_verbosity(val)
+            self.assertEqual(rv, expected)
+        with self.assertRaises(ValueError):
+            val = 'test'
+            cc._convert_verbosity(val)
+
+    def test_read_config_file(self):
+        config = cc.Configuration(None, env={}, config_files=())
+        d = config._read_config_file(self.config_file)
+        self.assertEqual(d, self.expected_config_dict)
+
+        for x in range(1, 4):
+            config_file = getattr(self, 'invalid_config_file' + str(x))
+            with self.assertRaises(ValueError):
+                config._read_config_file(config_file)
+
+    def test_read_env_var_config(self):
+        config = cc.Configuration(None, env={}, config_files=())
+        env = {
+            'a': 'a',
+            'CDIST_BETA': '1',
+            'CDIST_PATH': '/usr/local/cdist:~/.cdist',
+        }
+        expected = {
+            'beta': True,
+            'conf_dir': ['/usr/local/cdist', '~/.cdist', ],
+        }
+        d = config._read_env_var_config(env)
+        self.assertEqual(d, expected)
+
+        del env['CDIST_BETA']
+        del expected['beta']
+        d = config._read_env_var_config(env)
+        self.assertEqual(d, expected)
+
+    def test_read_args_config(self):
+        config = cc.Configuration(None, env={}, config_files=())
+        args = argparse.Namespace()
+        args.beta = False
+        args.conf_dir = '/usr/local/cdist:~/.cdist'
+        args.verbose = 3
+        args.tag = 'test'
+
+        expected = {
+            'beta': False,
+            'conf_dir': '/usr/local/cdist:~/.cdist',
+            'verbosity': 3,
+        }
+        args_dict = vars(args)
+        d = config._read_args_config(args_dict)
+        self.assertEqual(d, expected)
+        self.assertNotEqual(d, args_dict)
+
+    def test_update_config_dict(self):
+        config = {
+            'GLOBAL': {
+                'conf_dir': ['/usr/local/cdist', ],
+                'parallel': -1,
+            },
+        }
+        newconfig = {
+            'GLOBAL': {
+                'conf_dir': ['~/.cdist', ],
+                'parallel': 2,
+                'local_shell': '/usr/local/bin/sh',
+            },
+        }
+        expected = {
+            'GLOBAL': {
+                'conf_dir': ['/usr/local/cdist', '~/.cdist', ],
+                'parallel': 2,
+                'local_shell': '/usr/local/bin/sh',
+            },
+        }
+        configuration = cc.Configuration(None, env={}, config_files=())
+        configuration._update_config_dict(config, newconfig)
+        self.assertEqual(config, expected)
+
+    def test_update_config_dict_section(self):
+        config = {
+            'GLOBAL': {
+                'conf_dir': ['/usr/local/cdist', ],
+                'parallel': -1,
+            },
+        }
+        newconfig = {
+            'conf_dir': ['~/.cdist', ],
+            'parallel': 2,
+            'local_shell': '/usr/local/bin/sh',
+        }
+        expected = {
+            'GLOBAL': {
+                'conf_dir': ['/usr/local/cdist', '~/.cdist', ],
+                'parallel': 2,
+                'local_shell': '/usr/local/bin/sh',
+            },
+        }
+        configuration = cc.Configuration(None, env={}, config_files=())
+        configuration._update_config_dict_section('GLOBAL', config, newconfig)
+        self.assertEqual(config, expected)
+
+    def test_translate_values(self):
+        import multiprocessing
+
+        config = {
+            'GLOBAL': {
+                'beta': 'on',
+                'jobs': -1,
+                'parallel': 0,
+            },
+        }
+        expected = {
+            'GLOBAL': {
+                'beta': 'on',
+                'jobs': multiprocessing.cpu_count(),
+                'parallel': 0,
+            },
+        }
+        configuration = cc.Configuration(None, env={}, config_files=())
+        d = dict(config)
+        configuration._translate_values(d)
+        self.assertEqual(d, expected)
+
+        config['GLOBAL']['parallel'] = -1
+        expected['GLOBAL']['parallel'] = multiprocessing.cpu_count()
+        configuration = cc.Configuration(None, env={}, config_files=())
+        d = dict(config)
+        configuration._translate_values(d)
+        self.assertEqual(d, expected)
+
+    def test_get_and_adjust_config(self):
+        args = argparse.Namespace()
+        args.jobs = 8
+        args.dry_run = True
+        args.config_file = self.custom_config_file
+
+        env = {
+            'CDIST_BETA': '1',
+            'CDIST_PATH': '/usr/local/cdist:~/.cdist',
+            'CDIST_REMOTE_SHELL': '/usr/local/bin/sh',
+            'test': 'test',
+        }
+
+        expected = dict(self.expected_config_dict)
+        expected['GLOBAL']['conf_dir'] = ['/usr/local/cdist', '~/.cdist', ]
+        expected['GLOBAL']['remote_shell'] = '/usr/local/bin/sh'
+        expected['GLOBAL']['beta'] = True
+        expected['GLOBAL']['jobs'] = 8
+        expected['GLOBAL']['parallel'] = 4
+        expected['GLOBAL']['archiving'] = 'txz'
+
+        config_files = (self.config_file, )
+
+        configuration = cc.Configuration(args, env=env,
+                                         config_files=config_files)
+        self.assertIsNotNone(configuration.args)
+        self.assertIsNotNone(configuration.env)
+        self.assertIsNotNone(configuration.config_files)
+        self.assertEqual(configuration.config, expected)
+
+        got_config = configuration.get_config()
+        self.assertEqual(got_config, expected)
+
+        global_config = configuration.get_config('GLOBAL')
+        self.assertEqual(global_config, expected['GLOBAL'])
+
+        args = argparse.Namespace()
+        self.assertEqual(vars(args), {})
+        configuration.adjust_args(args)
+        dargs = vars(args)
+        expected_args = {
+            'beta': True,
+            'inventory_dir': None,
+            'cache_path_pattern': None,
+            'conf_dir': ['/usr/local/cdist', '~/.cdist', ],
+            'manifest': None,
+            'out_path': None,
+            'remote_out_path': None,
+            'remote_copy': None,
+            'remote_exec': None,
+            'jobs': 8,
+            'parallel': 4,
+            'verbose': cap.VERBOSE_INFO,
+            'use_archiving': 'txz',
+        }
+
+        self.assertEqual(dargs, expected_args)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/cdist/test/exec/local.py
+++ b/cdist/test/exec/local.py
@@ -28,8 +28,10 @@ import string
 import random
 import time
 import datetime
+import argparse
 
 import cdist
+import cdist.configuration as cc
 from cdist import test
 from cdist.exec import local
 
@@ -165,6 +167,9 @@ class LocalTestCase(test.CdistTestCase):
 
         os.environ['CDIST_PATH'] = conf_dir
 
+        configuration = cc.Configuration(argparse.Namespace(),
+                                         env=os.environ)
+
         link_test_local = local.Local(
             target_host=(
                 'localhost',
@@ -174,6 +179,7 @@ class LocalTestCase(test.CdistTestCase):
             base_root_path=self.host_base_path,
             host_dir_name=self.hostdir,
             exec_path=test.cdist_exec_path,
+            configuration=configuration
         )
 
         link_test_local._create_conf_path_and_link_conf_dirs()

--- a/docs/src/man1/cdist.rst
+++ b/docs/src/man1/cdist.rst
@@ -479,9 +479,10 @@ cdist obtains configuration data from the following sources in the following
 order:
 
     #. command-line options
-    #. configuration file specified in command-line
+    #. configuration file specified at command-line
+    #. configuration file specified in CDIST_CONFIG_FILE environment variable
     #. environment variables
-    #. user's configuration file (~/.cdist/cdist.cfg)
+    #. user's configuration file (~/.cdist.cfg)
     #. system-wide configuration file (/etc/cdist.cfg).
 
 cdist configuration file is in the INI file format. Currently it supports
@@ -501,8 +502,8 @@ The possible keywords and their meanings are as follows:
 
 :strong:`conf_dir`
     Comma separated list of configuration directories.
-    Note: values from different sources are accumulated into resulting
-    list of configuration directories.
+    If also specified at command line then values from command line are
+    appended to this value.
 
 :strong:`init_manifest`
     Specify default initial manifest.
@@ -686,6 +687,10 @@ CDIST_BETA
 
 CDIST_CACHE_PATH_PATTERN
     Custom cache path pattern.
+
+CDIST_CONFIG_FILE
+    Custom configuration file.
+
 
 EXIT STATUS
 -----------

--- a/docs/src/man1/cdist.rst
+++ b/docs/src/man1/cdist.rst
@@ -482,8 +482,11 @@ order:
     #. configuration file specified at command-line
     #. configuration file specified in CDIST_CONFIG_FILE environment variable
     #. environment variables
-    #. user's configuration file (~/.cdist.cfg)
-    #. system-wide configuration file (/etc/cdist.cfg).
+    #. user's configuration file (first one found of ~/.cdist.cfg,
+           $XDG_CONFIG_HOME/cdist/cdist.cfg, in specified order)
+    #. system-wide configuration file (/etc/cdist.cfg)
+
+if one exists.
 
 cdist configuration file is in the INI file format. Currently it supports
 only [GLOBAL] section.

--- a/docs/src/man1/cdist.rst
+++ b/docs/src/man1/cdist.rst
@@ -501,6 +501,8 @@ The possible keywords and their meanings are as follows:
 
 :strong:`conf_dir`
     Comma separated list of configuration directories.
+    Note: values from different sources are accumulated into resulting
+    list of configuration directories.
 
 :strong:`init_manifest`
     Specify default initial manifest.

--- a/docs/src/man1/cdist.rst
+++ b/docs/src/man1/cdist.rst
@@ -15,43 +15,45 @@ SYNOPSIS
 
     cdist banner [-h] [-q] [-v]
 
-    cdist config [-h] [-q] [-v] [-b] [-C CACHE_PATH_PATTERN] [-c CONF_DIR]
-                 [-i MANIFEST] [-j [JOBS]] [-n] [-o OUT_PATH]
-                 [-R [{tar,tgz,tbz2,txz}]] [-r REMOTE_OUT_DIR]
-                 [--remote-copy REMOTE_COPY] [--remote-exec REMOTE_EXEC]
-                 [-I INVENTORY_DIR] [-A] [-a] [-f HOSTFILE] [-p [HOST_MAX]]
-                 [-s] [-t]
+    cdist config [-h] [-q] [-v] [-b] [-g CONFIG_FILE]
+                 [-C CACHE_PATH_PATTERN] [-c CONF_DIR] [-i MANIFEST]
+                 [-j [JOBS]] [-n] [-o OUT_PATH] [-R [{tar,tgz,tbz2,txz}]]
+                 [-r REMOTE_OUT_DIR] [--remote-copy REMOTE_COPY]
+                 [--remote-exec REMOTE_EXEC] [-I INVENTORY_DIR] [-A] [-a]
+                 [-f HOSTFILE] [-p [HOST_MAX]] [-s] [-t]
                  [host [host ...]] 
 
-    cdist install [-h] [-q] [-v] [-b] [-C CACHE_PATH_PATTERN] [-c CONF_DIR]
-                  [-i MANIFEST] [-j [JOBS]] [-n] [-o OUT_PATH]
-                  [-R [{tar,tgz,tbz2,txz}]] [-r REMOTE_OUT_DIR]
-                  [--remote-copy REMOTE_COPY] [--remote-exec REMOTE_EXEC]
-                  [-I INVENTORY_DIR] [-A] [-a] [-f HOSTFILE] [-p [HOST_MAX]]
-                  [-s] [-t]
+    cdist install [-h] [-q] [-v] [-b] [-g CONFIG_FILE]
+                  [-C CACHE_PATH_PATTERN] [-c CONF_DIR] [-i MANIFEST]
+                  [-j [JOBS]] [-n] [-o OUT_PATH] [-R [{tar,tgz,tbz2,txz}]]
+                  [-r REMOTE_OUT_DIR] [--remote-copy REMOTE_COPY]
+                  [--remote-exec REMOTE_EXEC] [-I INVENTORY_DIR] [-A] [-a]
+                  [-f HOSTFILE] [-p [HOST_MAX]] [-s] [-t]
                   [host [host ...]] 
 
-    cdist inventory [-h] [-q] [-v] [-b] [-I INVENTORY_DIR]
+    cdist inventory [-h] [-q] [-v] [-b] [-g CONFIG_FILE] [-I INVENTORY_DIR]
                     {add-host,add-tag,del-host,del-tag,list} ...
 
-    cdist inventory add-host [-h] [-q] [-v] [-b] [-I INVENTORY_DIR]
-                             [-f HOSTFILE]
+    cdist inventory add-host [-h] [-q] [-v] [-b] [-g CONFIG_FILE]
+                             [-I INVENTORY_DIR] [-f HOSTFILE]
                              [host [host ...]]
 
-    cdist inventory add-tag [-h] [-q] [-v] [-b] [-I INVENTORY_DIR]
-                            [-f HOSTFILE] [-T TAGFILE] [-t TAGLIST]
+    cdist inventory add-tag [-h] [-q] [-v] [-b] [-g CONFIG_FILE]
+                            [-I INVENTORY_DIR] [-f HOSTFILE] [-T TAGFILE]
+                            [-t TAGLIST]
                             [host [host ...]]
 
-    cdist inventory del-host [-h] [-q] [-v] [-b] [-I INVENTORY_DIR] [-a]
-                             [-f HOSTFILE]
+    cdist inventory del-host [-h] [-q] [-v] [-b] [-g CONFIG_FILE]
+                             [-I INVENTORY_DIR] [-a] [-f HOSTFILE]
                              [host [host ...]]
 
-    cdist inventory del-tag [-h] [-q] [-v] [-b] [-I INVENTORY_DIR] [-a]
-                            [-f HOSTFILE] [-T TAGFILE] [-t TAGLIST]
+    cdist inventory del-tag [-h] [-q] [-v] [-b] [-g CONFIG_FILE]
+                            [-I INVENTORY_DIR] [-a] [-f HOSTFILE]
+                            [-T TAGFILE] [-t TAGLIST]
                             [host [host ...]]
 
-    cdist inventory list [-h] [-q] [-v] [-b] [-I INVENTORY_DIR] [-a]
-                         [-f HOSTFILE] [-H] [-t]
+    cdist inventory list [-h] [-q] [-v] [-b] [-g CONFIG_FILE]
+                         [-I INVENTORY_DIR] [-a] [-f HOSTFILE] [-H] [-t]
                          [host [host ...]]
 
     cdist shell [-h] [-q] [-v] [-s SHELL]
@@ -71,11 +73,11 @@ All commands accept the following options:
 
 .. option:: -h, --help
 
-    Show the help screen
+    Show the help screen.
 
 .. option:: -q, --quiet
 
-    Quiet mode: disables logging, including WARNING and ERROR
+    Quiet mode: disables logging, including WARNING and ERROR.
 
 .. option:: -v, --verbose
 
@@ -86,7 +88,7 @@ All commands accept the following options:
 
 .. option:: -V, --version
 
-   Show version and exit
+   Show version and exit.
 
 
 BANNER
@@ -98,26 +100,24 @@ cdist posters - a must have for every office.
 CONFIG/INSTALL
 --------------
 Configure/install one or more hosts.
+Install command is currently in beta.
 
 .. option:: -A, --all-tagged
 
-    use all hosts present in tags db
+    Use all hosts present in tags db. Currently in beta.
 
 .. option:: -a, --all
 
-    list hosts that have all specified tags, if -t/--tag
-    is specified
+    List hosts that have all specified tags, if -t/--tag
+    is specified.
 
 .. option:: -b, --beta
 
     Enable beta functionality.
     
-    Can also be enabled using CDIST_BETA env var.
-
 .. option:: -C CACHE_PATH_PATTERN, --cache-path-pattern CACHE_PATH_PATTERN
 
-    Sepcify custom cache path pattern. It can also be set by
-    CDIST_CACHE_PATH_PATTERN environment variable. If it is not set then
+    Sepcify custom cache path pattern. If it is not set then
     default hostdir is used. For more info on format see
     :strong:`CACHE PATH PATTERN FORMAT` below.
 
@@ -125,11 +125,7 @@ Configure/install one or more hosts.
 
     Add a configuration directory. Can be specified multiple times.
     If configuration directories contain conflicting types, explorers or
-    manifests, then the last one found is used. Additionally this can also
-    be configured by setting the CDIST_PATH environment variable to a colon
-    delimited list of config directories. Directories given with the
-    --conf-dir argument have higher precedence over those set through the
-    environment variable.
+    manifests, then the last one found is used.
 
 .. option:: -f HOSTFILE, --file HOSTFILE
 
@@ -139,19 +135,22 @@ Configure/install one or more hosts.
     read hosts from stdin. For the file format see
     :strong:`HOSTFILE FORMAT` below.
 
+.. option:: -g CONFIG_FILE, --config-file CONFIG_FILE
+
+    Use specified custom configuration file.
+
 .. option:: -I INVENTORY_DIR, --inventory INVENTORY_DIR
 
     Use specified custom inventory directory. Inventory
-    directory is set up by the following rules: if this
-    argument is set then specified directory is used, if
-    CDIST_INVENTORY_DIR env var is set then its value is
-    used, if HOME env var is set then ~/.cdit/inventory is
-    used, otherwise distribution inventory directory is
-    used.
+    directory is set up by the following rules: if cdist 
+    configuration resolves this value then specified
+    directory is used, if HOME env var is set then
+    ~/.cdit/inventory is used, otherwise distribution
+    inventory directory is used.
 
 .. option:: -i MANIFEST, --initial-manifest MANIFEST
 
-    Path to a cdist manifest or - to read from stdin
+    Path to a cdist manifest or - to read from stdin.
 
 .. option:: -j [JOBS], --jobs [JOBS]
 
@@ -162,11 +161,11 @@ Configure/install one or more hosts.
 
 .. option:: -n, --dry-run
 
-    Do not execute code
+    Do not execute code.
 
 .. option:: -o OUT_PATH, --out-dir OUT_PATH
 
-    Directory to save cdist output in
+    Directory to save cdist output in.
 
 .. option:: -p [HOST_MAX], --parallel [HOST_MAX]
 
@@ -179,29 +178,29 @@ Configure/install one or more hosts.
     Operate by using archiving with compression where
     apropriate. Supported values are: tar - tar archive,
     tgz - gzip tar archive (the default), tbz2 - bzip2 tar
-    archive and txz - lzma tar archive.
-
+    archive and txz - lzma tar archive. Currently in beta.
 
 .. option:: -r REMOTE_OUT_PATH, --remote-out-dir REMOTE_OUT_PATH
 
-    Directory to save cdist output in on the target host
+    Directory to save cdist output in on the target host.
 
 .. option:: -s, --sequential
 
-    Operate on multiple hosts sequentially (default)
+    Operate on multiple hosts sequentially (default).
 
 .. option:: --remote-copy REMOTE_COPY
 
-    Command to use for remote copy (should behave like scp)
+    Command to use for remote copy (should behave like scp).
 
 .. option:: --remote-exec REMOTE_EXEC
 
-    Command to use for remote execution (should behave like ssh)
+    Command to use for remote execution (should behave like ssh).
 
 .. option:: -t, --tag
 
-    host is specified by tag, not hostname/address; list
-    all hosts that contain any of specified tags
+    Host is specified by tag, not hostname/address; list
+    all hosts that contain any of specified tags.
+    Currently in beta.
 
 HOSTFILE FORMAT
 ~~~~~~~~~~~~~~~
@@ -247,16 +246,11 @@ Add host(s) to inventory database.
 
 .. option:: host
 
-    host(s) to add
+    Host(s) to add.
 
 .. option:: -b, --beta
 
-    Enable beta functionalities. Beta functionalities
-    include inventory command with all sub-commands and
-    all options; config sub-command options: -j/--jobs,
-    -t/--tag, -a/--all.
-
-    Can also be enabled using CDIST_BETA env var.
+    Enable beta functionality.
 
 .. option:: -f HOSTFILE, --file HOSTFILE
 
@@ -265,19 +259,18 @@ Add host(s) to inventory database.
     host or host file is specified then, by default, read
     from stdin. Hostfile format is the same as config hostfile format.
 
-.. option:: -h, --help
+.. option:: -g CONFIG_FILE, --config-file CONFIG_FILE
 
-    show this help message and exit
+    Use specified custom configuration file.
 
 .. option:: -I INVENTORY_DIR, --inventory INVENTORY_DIR
 
     Use specified custom inventory directory. Inventory
-    directory is set up by the following rules: if this
-    argument is set then specified directory is used, if
-    CDIST_INVENTORY_DIR env var is set then its value is
-    used, if HOME env var is set then ~/.cdist/inventory is
-    used, otherwise distribution inventory directory is
-    used.
+    directory is set up by the following rules: if cdist 
+    configuration resolves this value then specified
+    directory is used, if HOME env var is set then
+    ~/.cdit/inventory is used, otherwise distribution
+    inventory directory is used.
 
 
 INVENTORY ADD-TAG
@@ -286,16 +279,11 @@ Add tag(s) to inventory database.
 
 .. option:: host
 
-    list of host(s) for which tags are added
+    List of host(s) for which tags are added.
 
 .. option:: -b, --beta
 
-    Enable beta functionalities. Beta functionalities
-    include inventory command with all sub-commands and
-    all options; config sub-command options: -j/--jobs,
-    -t/--tag, -a/--all.
-
-    Can also be enabled using CDIST_BETA env var.
+    Enable beta functionality.
 
 .. option:: -f HOSTFILE, --file HOSTFILE
 
@@ -306,15 +294,18 @@ Add tag(s) to inventory database.
     are specified then tags are read from stdin and are
     added to all hosts. Hostfile format is the same as config hostfile format.
 
+.. option:: -g CONFIG_FILE, --config-file CONFIG_FILE
+
+    Use specified custom configuration file.
+
 .. option:: -I INVENTORY_DIR, --inventory INVENTORY_DIR
 
     Use specified custom inventory directory. Inventory
-    directory is set up by the following rules: if this
-    argument is set then specified directory is used, if
-    CDIST_INVENTORY_DIR env var is set then its value is
-    used, if HOME env var is set then ~/.cdist/inventory is
-    used, otherwise distribution inventory directory is
-    used.
+    directory is set up by the following rules: if cdist 
+    configuration resolves this value then specified
+    directory is used, if HOME env var is set then
+    ~/.cdit/inventory is used, otherwise distribution
+    inventory directory is used.
 
 .. option:: -T TAGFILE, --tag-file TAGFILE
 
@@ -328,7 +319,7 @@ Add tag(s) to inventory database.
 .. option:: -t TAGLIST, --taglist TAGLIST
 
     Tag list to be added for specified host(s), comma
-    separated values
+    separated values.
 
 
 INVENTORY DEL-HOST
@@ -337,20 +328,15 @@ Delete host(s) from inventory database.
 
 .. option:: host
 
-    host(s) to delete
+    Host(s) to delete.
 
 .. option:: -a, --all
 
-    Delete all hosts
+    Delete all hosts.
 
 .. option:: -b, --beta
 
-    Enable beta functionalities. Beta functionalities
-    include inventory command with all sub-commands and
-    all options; config sub-command options: -j/--jobs,
-    -t/--tag, -a/--all.
-
-    Can also be enabled using CDIST_BETA env var.
+    Enable beta functionality.
 
 .. option:: -f HOSTFILE, --file HOSTFILE
 
@@ -359,15 +345,18 @@ Delete host(s) from inventory database.
     host or host file is specified then, by default, read
     from stdin. Hostfile format is the same as config hostfile format.
 
+.. option:: -g CONFIG_FILE, --config-file CONFIG_FILE
+
+    Use specified custom configuration file.
+
 .. option:: -I INVENTORY_DIR, --inventory INVENTORY_DIR
 
     Use specified custom inventory directory. Inventory
-    directory is set up by the following rules: if this
-    argument is set then specified directory is used, if
-    CDIST_INVENTORY_DIR env var is set then its value is
-    used, if HOME env var is set then ~/.cdist/inventory is
-    used, otherwise distribution inventory directory is
-    used.
+    directory is set up by the following rules: if cdist 
+    configuration resolves this value then specified
+    directory is used, if HOME env var is set then
+    ~/.cdit/inventory is used, otherwise distribution
+    inventory directory is used.
 
 
 INVENTORY DEL-TAG
@@ -376,20 +365,15 @@ Delete tag(s) from inventory database.
 
 .. option:: host
 
-    list of host(s) for which tags are deleted
+    List of host(s) for which tags are deleted.
 
 .. option:: -a, --all
 
-    Delete all tags for specified host(s)
+    Delete all tags for specified host(s).
 
 .. option:: -b, --beta
 
-    Enable beta functionalities. Beta functionalities
-    include inventory command with all sub-commands and
-    all options; config sub-command options: -j/--jobs,
-    -t/--tag, -a/--all.
-
-    Can also be enabled using CDIST_BETA env var.
+    Enable beta functionality.
 
 .. option:: -f HOSTFILE, --file HOSTFILE
 
@@ -401,15 +385,18 @@ Delete tag(s) from inventory database.
     from stdin and are deleted from all hosts. Hostfile
     format is the same as config hostfile format.
 
+.. option:: -g CONFIG_FILE, --config-file CONFIG_FILE
+
+    Use specified custom configuration file.
+
 .. option:: -I INVENTORY_DIR, --inventory INVENTORY_DIR
 
     Use specified custom inventory directory. Inventory
-    directory is set up by the following rules: if this
-    argument is set then specified directory is used, if
-    CDIST_INVENTORY_DIR env var is set then its value is
-    used, if HOME env var is set then ~/.cdist/inventory is
-    used, otherwise distribution inventory directory is
-    used.
+    directory is set up by the following rules: if cdist 
+    configuration resolves this value then specified
+    directory is used, if HOME env var is set then
+    ~/.cdit/inventory is used, otherwise distribution
+    inventory directory is used.
 
 .. option:: -T TAGFILE, --tag-file TAGFILE
 
@@ -423,7 +410,7 @@ Delete tag(s) from inventory database.
 .. option:: -t TAGLIST, --taglist TAGLIST
 
     Tag list to be deleted for specified host(s), comma
-    separated values
+    separated values.
 
 
 INVENTORY LIST
@@ -432,21 +419,16 @@ List inventory database.
 
 .. option::  host
 
-    host(s) to list
+    Host(s) to list.
 
 .. option:: -a, --all
 
-    list hosts that have all specified tags, if -t/--tag
-    is specified
+    List hosts that have all specified tags, if -t/--tag
+    is specified.
 
 .. option:: -b, --beta
 
-    Enable beta functionalities. Beta functionalities
-    include inventory command with all sub-commands and
-    all options; config sub-command options: -j/--jobs,
-    -t/--tag, -a/--all.
-
-    Can also be enabled using CDIST_BETA env var.
+    Enable beta functionality.
 
 .. option:: -f HOSTFILE, --file HOSTFILE
 
@@ -455,24 +437,27 @@ List inventory database.
     host or host file is specified then, by default, list
     all. Hostfile format is the same as config hostfile format.
 
+.. option:: -g CONFIG_FILE, --config-file CONFIG_FILE
+
+    Use specified custom configuration file.
+
 .. option:: -H, --host-only
 
-    Suppress tags listing
+    Suppress tags listing.
 
 .. option:: -I INVENTORY_DIR, --inventory INVENTORY_DIR
 
     Use specified custom inventory directory. Inventory
-    directory is set up by the following rules: if this
-    argument is set then specified directory is used, if
-    CDIST_INVENTORY_DIR env var is set then its value is
-    used, if HOME env var is set then ~/.cdist/inventory is
-    used, otherwise distribution inventory directory is
-    used.
+    directory is set up by the following rules: if cdist 
+    configuration resolves this value then specified
+    directory is used, if HOME env var is set then
+    ~/.cdit/inventory is used, otherwise distribution
+    inventory directory is used.
 
 .. option:: -t, --tag
 
-    host is specified by tag, not hostname/address; list
-    all hosts that contain any of specified tags
+    Host is specified by tag, not hostname/address; list
+    all hosts that contain any of specified tags.
 
 
 SHELL
@@ -486,6 +471,76 @@ usage. Its primary use is for debugging type parameters.
 
     Select shell to use, defaults to current shell. Used shell should
     be POSIX compatible shell.
+
+
+CONFIGURATION FILE
+------------------
+cdist obtains configuration data from the following sources in the following
+order:
+
+    #. command-line options
+    #. configuration file specified in command-line
+    #. environment variables
+    #. user's configuration file (~/.cdist/cdist.cfg)
+    #. system-wide configuration file (/etc/cdist.cfg).
+
+cdist configuration file is in the INI file format. Currently it supports
+only [GLOBAL] section.
+The possible keywords and their meanings are as follows:
+
+:strong:`archiving`
+    Use specified archiving. Valid values include:
+    'none', 'tar', 'tgz', 'tbz2' and 'txz'.
+
+:strong:`beta`
+    Enable beta functionality. It recognizes boolean values from
+    'yes'/'no', 'on'/'off', 'true'/'false' and '1'/'0'
+
+:strong:`cache_path_pattern`
+    Specify cache path pattern.
+
+:strong:`conf_dir`
+    Comma separated list of configuration directories.
+
+:strong:`init_manifest`
+    Specify default initial manifest.
+
+:strong:`inventory_dir`
+    Specify inventory directory.
+
+:strong:`jobs`
+    Specify number of jobs for parallel processing. If -1 then the default,
+    number of CPU's in the system is used. If 0 then parallel processing in
+    jobs is disabled. If set to positive number then specified maximum
+    number of processes will be used.
+
+:strong:`local_shell`
+    Shell command used for local execution.
+
+:strong:`out_path`
+    Directory to save cdist output in.
+
+:strong:`parallel`
+    Process hosts in parallel. If -1 then the default, number of CPU's in
+    the system is used. If 0 then parallel processing of hosts is disabled.
+    If set to positive number then specified maximum number of processes
+    will be used.
+
+:strong:`remote_copy`
+    Command to use for remote copy (should behave like scp).
+
+:strong:`remote_exec`
+    Command to use for remote execution (should behave like ssh).
+
+:strong:`remote_out_path`
+    Directory to save cdist output in on the target host.
+
+:strong:`remote_shell`
+    Shell command at remote host used for remote execution.
+
+:strong:`verbosity`
+    Set verbosity level. Valid values are: 
+    'ERROR', 'WARNING', 'INFO', 'VERBOSE', 'DEBUG', 'TRACE' and 'QUIET'.
 
 
 FILES
@@ -502,6 +557,10 @@ cdist/conf
 cdist/inventory
     The distribution inventory directory.
     This path is relative to cdist installation directory.
+/etc/cdist.cfg
+    Global cdist configuration file, if exists.
+~/.cdist/cdist.cfg
+    Local cdist configuration file, if exists.
 
 NOTES
 -----

--- a/docs/src/man1/cdist.rst
+++ b/docs/src/man1/cdist.rst
@@ -540,7 +540,7 @@ The possible keywords and their meanings are as follows:
 
 :strong:`verbosity`
     Set verbosity level. Valid values are: 
-    'ERROR', 'WARNING', 'INFO', 'VERBOSE', 'DEBUG', 'TRACE' and 'QUIET'.
+    'ERROR', 'WARNING', 'INFO', 'VERBOSE', 'DEBUG', 'TRACE' and 'OFF'.
 
 
 FILES

--- a/scripts/cdist
+++ b/scripts/cdist
@@ -23,6 +23,7 @@
 
 import collections
 import logging
+import cdist.configuration
 
 
 def commandline():
@@ -44,7 +45,14 @@ def commandline():
     cdist.argparse.handle_loglevel(args)
 
     log.verbose("version %s" % cdist.VERSION)
-    log.trace(args)
+
+    cfg = cdist.configuration.Configuration(args)
+    log.trace('configuration: {}'.format(cfg.get_config()))
+
+    log.trace('args: {}'.format(args))
+
+    cfg.adjust_args(args)
+    log.trace('adjusted args: {}'.format(args))
 
     # Work around python 3.3 bug:
     # http://bugs.python.org/issue16308

--- a/scripts/cdist
+++ b/scripts/cdist
@@ -22,18 +22,17 @@
 #
 
 import logging
-import cdist.configuration
+import cdist
+import cdist.argparse
+import cdist.banner
+import cdist.config
+import cdist.install
+import cdist.shell
+import cdist.inventory
 
 
 def commandline():
     """Parse command line"""
-
-    import cdist.argparse
-    import cdist.banner
-    import cdist.config
-    import cdist.install
-    import cdist.shell
-    import cdist.inventory
 
     parser, cfg = cdist.argparse.parse_and_configure(sys.argv[1:])
     args = cfg.get_args()
@@ -68,9 +67,8 @@ if __name__ == "__main__":
     exit_code = 0
 
     try:
-        import os
         import re
-        import cdist
+        import os
 
         log = logging.getLogger("cdist")
 

--- a/scripts/cdist
+++ b/scripts/cdist
@@ -35,21 +35,8 @@ def commandline():
     import cdist.shell
     import cdist.inventory
 
-    parser = cdist.argparse.get_parsers()
-    args = parser['main'].parse_args(sys.argv[1:])
-
-    # Loglevels are handled globally in here
-    cdist.argparse.handle_loglevel(args)
-
-    log.verbose("version %s" % cdist.VERSION)
-
-    cfg = cdist.configuration.Configuration(args)
-    log.trace('configuration: {}'.format(cfg.get_config()))
-
-    log.trace('args: {}'.format(args))
-
-    cfg.adjust_args(args)
-    log.trace('adjusted args: {}'.format(args))
+    parser, cfg = cdist.argparse.parse_and_configure(sys.argv[1:])
+    args = cfg.get_args()
 
     # Work around python 3.3 bug:
     # http://bugs.python.org/issue16308
@@ -66,7 +53,6 @@ def commandline():
         parser['main'].print_help()
         sys.exit(0)
 
-    cdist.argparse.check_beta(vars(args))
     args.func(args)
 
 


### PR DESCRIPTION
This is a proposal for cdist config file implementation.

cdist obtains configuration data from the following sources in the following order:

- command-line options
- configuration file specified in command-line (new -g CONFIG_FILE option)
- environment variables
- user's configuration file (~/.cdist/cdist.cfg)
- system-wide configuration file (/etc/cdist.cfg).

cdist configuration file is in the INI file format. Currently it supports only [GLOBAL] section. The possible keywords and their meanings are as follows:

**archiving**
    Use specified archiving. Valid values include: 'none', 'tar', 'tgz', 'tbz2' and 'txz'.
**beta**
    Enable beta functionality. It recognizes boolean values from 'yes'/'no', 'on'/'off', 'true'/'false' and '1'/'0'
**cache_path_pattern**
    Specify cache path pattern.
**conf_dir**
    Comma separated list of configuration directories.
**init_manifest**
    Specify default initial manifest.
**inventory_dir**
    Specify inventory directory.
**jobs**
    Specify number of jobs for parallel processing. If -1 then the default, number of CPU's in the system is used. If 0 then parallel processing in jobs is disabled. If set to positive number then specified maximum number of processes will be used.
**local_shell**
    Shell command used for local execution.
**out_path**
    Directory to save cdist output in.
**parallel**
    Process hosts in parallel. If -1 then the default, number of CPU's in the system is used. If 0 then parallel processing of hosts is disabled. If set to positive number then specified maximum number of processes will be used.
**remote_copy**
    Command to use for remote copy (should behave like scp).
**remote_exec**
    Command to use for remote execution (should behave like ssh).
**remote_out_path**
    Directory to save cdist output in on the target host.
**remote_shell**
    Shell command at remote host used for remote execution.
**verbosity**
    Set verbosity level. Valid values are: 'ERROR', 'WARNING', 'INFO', 'VERBOSE', 'DEBUG', 'TRACE' and 'QUIET'. 
