### PR TITLE
Explorer pipes output of apt-key list, which always generates:

### DIFF
--- a/cdist/conf/type/__apt_key_uri/explorer/state
+++ b/cdist/conf/type/__apt_key_uri/explorer/state
@@ -27,6 +27,6 @@ else
    name="$__object_id"
 fi
 
-apt-key list | grep -Fqe "$name" \
+apt-key list 2> /dev/null | grep -Fqe "$name" \
    && echo present \
    || echo absent


### PR DESCRIPTION
Warning: apt-key output should not be parsed (stdout is not a terminal)
on stderr. Redirect stderr of apt-key to /dev/null to prevent output in
cdist run.