### PR TITLE
__package_pkg_openbsd: support using /etc/installurl

### DIFF
--- a/cdist/conf/type/__package_pkg_openbsd/explorer/has_installurl
+++ b/cdist/conf/type/__package_pkg_openbsd/explorer/has_installurl
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# Retrieve the installurl(5), as introduced in OpenBSD 6.1
+#
+# As of 6.1, the file is supposed to contained a single line
+# with the URL used to install from during install or upgrade.
+#
+# Allow for expansion and take the first non-commented (#) line.
+#
+
+if [ -f /etc/installurl ]; then
+	printf 'yes'
+else
+	printf 'no'
+fi
+
+exit 0

--- a/cdist/conf/type/__package_pkg_openbsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_openbsd/gencode-remote
@@ -63,7 +63,11 @@ pkg_version="$(cat "$__object/explorer/pkg_version")"
 if [ -f "$__object/parameter/pkg_path" ]; then                                  
   pkg_path="$(cat "$__object/parameter/pkg_path")"                              
 else
-  pkg_path="ftp://ftp.openbsd.org/pub/OpenBSD/$os_version/packages/$machine/"
+  has_installurl=$(cat "${__object}/explorer/has_installurl")
+  if [ Xyes != X"${has_installurl}" ]; then
+      # there is no default PKG_PATH, try to provide one
+      pkg_path="ftp://ftp.openbsd.org/pub/OpenBSD/$os_version/packages/$machine/"
+  fi
 fi                                                                              
 
 if [ "$pkg_version" ]; then
@@ -78,7 +82,9 @@ case "$state_should" in
     present)
         # use this because pkg_add doesn't properly handle errors
         cat << eof
-export PKG_PATH="$pkg_path"                                              
+if [ X != X"${pkg_path}" ]; then
+    PKG_PATH="${pkg_path}"; export PKG_PATH
+fi
 status=\$(pkg_add "$pkgopts" "$pkgid" 2>&1)
 pkg_info | grep "^${name}.*${version}.*${flavor}" > /dev/null 2>&1
 


### PR DESCRIPTION
In 6.1, OpenBSD introduced installurl(5), which contains
the URL where sets were installed from during install or upgrade.
The content of this file is used by pkg_add(1) if PKG_PATH is
not defined.

This commit changes the behavior of __package_pkg_openbsd to omit
setting PKG_PATH to a hard-coded value if --pkg_path is not provided.
This, in turn, makes pkg_add(1) use installurl(5).