### PR TITLE
__package_pkg_openbsd: support the empty flavor

### DIFF
--- a/cdist/conf/type/__package_pkg_openbsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_openbsd/gencode-remote
@@ -52,6 +52,8 @@ elif [ -n "$version" ]; then
    pkgid="$name-$version"
 elif [ -n "$flavor" ]; then
    pkgid="$name--$flavor"
+elif [ -f "$__object/parameter/flavor" ]; then
+   pkgid="$name--"
 else
    pkgid="$name"
 fi


### PR DESCRIPTION
Adds support for specifying an empty flavor by passing --flavor "".

This commit prevents pkg_add(1) from trying to read from stdin for flavor selection
when there is ambiguity and the empty flavor is desired, by specifying --flavor "".