### PR TITLE
__user_groups: Support OpenBSD

### DIFF
--- a/cdist/conf/type/__user_groups/gencode-remote
+++ b/cdist/conf/type/__user_groups/gencode-remote
@@ -42,10 +42,10 @@ if [ -z "$changed_groups" ]; then
 fi
 
 for group in $changed_groups; do
-   if [ "$os" = "netbsd" ]; then
+   if [ "$os" = "netbsd" ] || [ "$os" = "openbsd" ]; then
       case "$state_should" in
          present) echo "usermod -G \"$group\" \"$user\"" ;;
-         absent) echo 'NetBSD does not have a command to remove a user from a group' >&2 ; exit 1 ;;
+         absent) echo 'NetBSD and OpenBSD do not have a command to remove a user from a group' >&2 ; exit 1 ;;
       esac
    elif [ "$os" = "freebsd" ]; then
       case "$state_should" in


### PR DESCRIPTION
OpenBSD's usermod(8) interface is similary to NetBSD's.
This commit makes __user_groups support it explicitly.

https://man.openbsd.org/usermod.8
http://netbsd.gw.com/cgi-bin/man-cgi?usermod++NetBSD-current