### PR TITLE
Improve __daemontools on FreeBSD

### DIFF
--- a/cdist/conf/type/__daemontools/man.rst
+++ b/cdist/conf/type/__daemontools/man.rst
@@ -21,10 +21,15 @@ OPTIONAL PARAMETERS
 from-package
    Package to install. Must be compatible with the original daemontools. Example: daemontools-encore. Default: daemontools.
 
+servicedir
+   Directory to scan for services. Default: `/service`
+
+
 BOOLEAN PARAMETERS
 ------------------
 install-init-script
    Add an init script and set it to start on boot.
+
 
 EXAMPLES
 --------

--- a/cdist/conf/type/__daemontools/manifest
+++ b/cdist/conf/type/__daemontools/manifest
@@ -1,17 +1,34 @@
-#!/bin/sh -e
+;#!/bin/sh -e
 
 pkg=$(cat "$__object/parameter/from-package")
+servicedir=$(cat "$__object/parameter/servicedir")
 
 __package $pkg
+__directory $servicedir --mode 755
 
 if [ -f "$__object/parameter/install-init-script" ]; then
+	os=$(cat "$__global/explorer/os")
 	init=$(cat "$__global/explorer/init")
+
 	case $init in
 		init)
-			__config_file /etc/init.d/svscan --mode 755 --source "$__type/files/init.d-svscan"
-			require="$require __config_file/etc/init.d/svscan" __start_on_boot svscan
-			require="$require __start_on_boot/svscan" __process svscan --start 'service svscan start'
-		;;
+			case $os in
+				freebsd)
+					__config_file /etc/rc.conf.d/svscan --source - <<-EOT
+						svscan_enable="YES"
+        				        svscan_servicedir="$servicedir"
+        				EOT
+					require="$require __package/$pkg __directory/$servicedir __config_file/etc/rc.conf.d/svscan" \
+					__process svscan --start 'service svscan start'
+				;;
+				*)
+					__config_file /etc/init.d/svscan --mode 755 --source "$__type/files/init.d-svscan"
+					require="$require __config_file/etc/init.d/svscan" __start_on_boot svscan
+					require="$require __package/$pkg __directory/$servicedir __start_on_boot/svscan" \
+					__process svscan --start 'service svscan start'
+				;;
+			esac
+			;;
 		*)
 			echo "Your init system ($init) is not supported by this type. Submit a patch at github.com/ungleich/cdist!"
 			exit 1

--- a/cdist/conf/type/__daemontools/manifest
+++ b/cdist/conf/type/__daemontools/manifest
@@ -1,4 +1,4 @@
-;#!/bin/sh -e
+#!/bin/sh -e
 
 pkg=$(cat "$__object/parameter/from-package")
 servicedir=$(cat "$__object/parameter/servicedir")

--- a/cdist/conf/type/__daemontools/manifest
+++ b/cdist/conf/type/__daemontools/manifest
@@ -16,8 +16,8 @@ if [ -f "$__object/parameter/install-init-script" ]; then
 				freebsd)
 					__config_file /etc/rc.conf.d/svscan --source - <<-EOT
 						svscan_enable="YES"
-        				        svscan_servicedir="$servicedir"
-        				EOT
+						svscan_servicedir="$servicedir"
+					EOT
 					require="$require __package/$pkg __directory/$servicedir __config_file/etc/rc.conf.d/svscan" \
 					__process svscan --start 'service svscan start'
 				;;

--- a/cdist/conf/type/__daemontools/parameter/default/servicedir
+++ b/cdist/conf/type/__daemontools/parameter/default/servicedir
@@ -1,0 +1,1 @@
+/service

--- a/cdist/conf/type/__daemontools/parameter/optional
+++ b/cdist/conf/type/__daemontools/parameter/optional
@@ -1,1 +1,2 @@
 from-package
+servicedir


### PR DESCRIPTION
Make __daemontools do the right thing on FreeBSD when called with `--install-init-script`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ungleich/cdist/567)
<!-- Reviewable:end -->
