### PR TITLE
__package_pkg_openbsd: fix use of --name

### DIFF
--- a/cdist/conf/type/__package_pkg_openbsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_openbsd/gencode-remote
@@ -41,7 +41,7 @@ fi
 pkgopts="-x"
 
 if [ -f "$__object/parameter/name" ]; then
-   name="$__object/parameter/name"
+   name=$(cat "$__object/parameter/name")
 else
    name="$__object_id"
 fi


### PR DESCRIPTION
Fixes the improper use of the file holding the value of the 'name'
option.