### PR TITLE
__package_pkg_openbsd: fix pkg_version explorer

### DIFF
--- a/cdist/conf/type/__package_pkg_openbsd/explorer/pkg_version
+++ b/cdist/conf/type/__package_pkg_openbsd/explorer/pkg_version
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # 2011 Andi Brönnimann (andi-cdist at v-net.ch)
+# Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
 #
 # This file is part of cdist.
 #
@@ -28,4 +29,4 @@ else
 fi
 
 #TODO: Is there a better way?
-pkg_info | grep "$name" | sed 's .*\(-[0-9.][0-9.]*\).* \1 ' | sed 's/-//'
+pkg_info | grep "^$name-[0-9]" | sed 's|.*\(-[0-9][0-9.]*\).*|\1|' | sed 's/-//'


### PR DESCRIPTION
The pkg_version explorer will fail to properly detect if a package
is installed when a package's name is present in the description of
a package (as returned by pkg_info).

Currently, trying to install libtool fails due to incorrect parsing:

    $ pkg_info | grep libtool
    libltdl-2.4.2p1     GNU libtool system independent dlopen wrapper

Additionally, trying to install nagios results in the following output:

    $ pkg_info | grep nagios
    nagios-4.0.8p3-chroot host and service monitor
    nagios-web-4.0.8p2-chroot cgis and webpages for nagios

This commit fixes detection by properly parsing pkg_info's output.
Specifically, descriptions are ignored and package names are properly
extracted.