### PR TITLE
Make __cdist_loglevel value more expressive.

### DIFF
--- a/cdist/conf/type/__install_config/gencode-local
+++ b/cdist/conf/type/__install_config/gencode-local
@@ -24,16 +24,16 @@ remote_copy="$__type/files/remote/copy"
 
 cdist_args=""
 case "$__cdist_loglevel" in
-   20)
+   INFO)
       cdist_args="-v"
    ;;
-   15)
+   VERBOSE)
       cdist_args="-vv"
    ;;
-   10)
+   DEBUG)
       cdist_args="-vvv"
    ;;
-   5)
+   TRACE)
       cdist_args="-vvvv"
    ;;
 esac

--- a/cdist/conf/type/__install_stage/gencode-remote
+++ b/cdist/conf/type/__install_stage/gencode-remote
@@ -23,7 +23,7 @@ uri="$(cat "$__object/parameter/uri" 2>/dev/null \
 target="$(cat "$__object/parameter/target")"
 
 case "$__cdist_loglevel" in
-    10|5)  # DEBUG or TRACE
+    DEBUG|TRACE)
         curl="curl"
         tar="tar -xvzp"
     ;;

--- a/cdist/core/manifest.py
+++ b/cdist/core/manifest.py
@@ -114,7 +114,7 @@ class Manifest(object):
         }
 
         self.env.update(
-            {'__cdist_loglevel': str(self.log.getEffectiveLevel())})
+            {'__cdist_loglevel': logging.getLevelName(self.log.getEffectiveLevel())})
 
     def _open_logger(self):
         self.log = logging.getLogger(self.target_host[0])

--- a/cdist/emulator.py
+++ b/cdist/emulator.py
@@ -111,12 +111,18 @@ class Emulator(object):
 
         if '__cdist_loglevel' in self.env:
             try:
-                level = int(self.env['__cdist_loglevel'])
+                loglevel = self.env['__cdist_loglevel']
+                # For a text level it returns its numerical value.
+                level = logging.getLevelName(loglevel)
             except ValueError:
                 level = logging.WARNING
         else:
             level = logging.WARNING
-        logging.root.setLevel(level)
+        try:
+            logging.root.setLevel(level)
+        except (ValueError, TypeError):
+            # if invalid __cdist_loglevel value
+            logging.root.setLevel(logging.WARNING)
 
         self.log = logging.getLogger(self.target_host[0])
 

--- a/cdist/test/manifest/__init__.py
+++ b/cdist/test/manifest/__init__.py
@@ -137,6 +137,7 @@ class ManifestTestCase(test.CdistTestCase):
         self.log.setLevel(logging.DEBUG)
         manifest = cdist.core.manifest.Manifest(self.target_host, self.local)
         self.assertTrue("__cdist_loglevel" in manifest.env)
+        self.assertEqual(manifest.env["__cdist_loglevel"], 'DEBUG')
         self.log.setLevel(current_level)
 
 

--- a/docs/changelog
+++ b/docs/changelog
@@ -12,6 +12,7 @@ next:
 	* Type __package_pkg_openbsd: Fix pkg_version explorer (Philippe Gregoire)
 	* Documentation: Document __cdist_loglevel type variable (Darko Poljak)
 	* Type __install_stage: Fix __debug -> __cdist_loglevel (Darko Poljak)
+	* Core, types: Make __cdist_loglevel value more expressive (Darko Poljak)
 
 4.6.1: 2017-08-30
 	* Type __user: Explore with /etc files (passwd, group, shadow) (Philippe Gregoire)

--- a/docs/src/cdist-reference.rst.sh
+++ b/docs/src/cdist-reference.rst.sh
@@ -199,9 +199,8 @@ Environment variables (for reading)
 The following environment variables are exported by cdist:
 
 __cdist_loglevel
-    Value of cdist log level. One of 60, 40, 30, 20, 15, 10 and 5 where
-    the meaning is OFF, ERROR, WARNING, INFO, VERBOSE, DEBUG and TRACE,
-    respectively.
+    String value of cdist log level. One of OFF, ERROR, WARNING, INFO,
+    VERBOSE, DEBUG and TRACE.
     Available for: initial manifest, type manifest, type gencode.
 __explorer
     Directory that contains all global explorers.

--- a/docs/src/cdist-type.rst
+++ b/docs/src/cdist-type.rst
@@ -334,9 +334,8 @@ So when you generate a script with the following content, it will work:
 Log level in types
 ------------------
 cdist log level can be accessed from __cdist_loglevel variable.
-Value is one of 60, 40, 30, 20, 15, 10 and 5 where the meaning is
-OFF, ERROR, WARNING, INFO, VERBOSE, DEBUG and TRACE, respectively.
-It is available for initial manifest, type manifest and type gencode.
+Value is a string, one of OFF, ERROR, WARNING, INFO, VERBOSE, DEBUG and
+TRACE. It is available for initial manifest, type manifest and type gencode.
 
 
 Hints for typewriters


### PR DESCRIPTION
With these changes you no longer have __cdist_loglevel values 40, 30, 10, etc. but "ERROR", "INFO", "DEBUG", etc.
`if [ "$__cdist_loglevel" = "DEBUG" ]`.