### PR TITLE
Bug/dotman docs fix

### DIFF
--- a/docs/src/cdist-install.rst
+++ b/docs/src/cdist-install.rst
@@ -133,6 +133,9 @@ some other custom .cdist directory, e.g. /opt/cdist then use:
 
     make DOT_CDIST_PATH=/opt/cdist dotman
 
+Note that `dotman`-target has to be built before a `make docs`-run, otherwise
+the custom man-pages are not picked up.
+
 Python package
 ~~~~~~~~~~~~~~
 

--- a/docs/src/cdist-install.rst
+++ b/docs/src/cdist-install.rst
@@ -131,7 +131,7 @@ some other custom .cdist directory, e.g. /opt/cdist then use:
 
 .. code-block:: sh
 
-    DOT_CDIST_PATH=/opt/cdist make dotman
+    make DOT_CDIST_PATH=/opt/cdist dotman
 
 Python package
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
The current documented way for custom `man.rst`-file from a non-standard location (i.e. not in `~/.cdist/` does not work.

The proposed documentation changes is one possible solution to this. We could also use `DOT_CDIST_PATH=/opt/cdist make -e`, but that's more intrusive and may have more side-effects as the full environment of the user can override make-vars.

I also found the `dotman` needs to be build 1st, so a note on that was added too.