### PR TITLE
fix explorer/os for devuan ascii

### DIFF
--- a/cdist/conf/explorer/os
+++ b/cdist/conf/explorer/os
@@ -51,15 +51,17 @@ if grep -q ^DISTRIB_ID=Ubuntu /etc/lsb-release 2>/dev/null; then
    exit 0
 fi
 
+# devuan ascii has both devuan_version and debian_version, so we need to check devuan_version first!
+if [ -f /etc/devuan_version ]; then
+   echo devuan
+   exit 0
+fi
+
 if [ -f /etc/debian_version ]; then
    echo debian
    exit 0
 fi
 
-if [ -f /etc/devuan_version ]; then
-   echo devuan
-   exit 0
-fi
 ###
 
 if [ -f /etc/gentoo-release ]; then


### PR DESCRIPTION
Fix: explorer/os is reporting 'debian' instead of 'devuan' for Devuan Ascii

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ungleich/cdist/588)
<!-- Reviewable:end -->
