### PR TITLE
Fix for __line containing single quotes: #154.

### DIFF
--- a/cdist/conf/type/__line/gencode-remote
+++ b/cdist/conf/type/__line/gencode-remote
@@ -81,7 +81,7 @@ tmpfile=\$(mktemp ${file}.cdist.XXXXXXXXXX)
 if [ -f "$file" ]; then
    cp -p "$file" "\$tmpfile"
 fi
-grep -v $greparg '$regex' '$file' > \$tmpfile || true
+grep -v $greparg "$regex" '$file' > \$tmpfile || true
 mv -f "\$tmpfile" "$file"
 eof
         echo "removed" >> "$__messages_out"


### PR DESCRIPTION
This fixes:
https://github.com/ungleich/cdist/issues/154#issuecomment-342522050

@telmich Take a look.
@winduptoy With this fix you have to use it like:
<pre>
echo __line /etc/TEST.txt --line "dc_eximconfig_configtype=\'local\'" --state absent | cdist config --initial-manifest - -v myhost
</pre>
