### PR TITLE
Support explorers when the filesystem is mounted non-executable

### DIFF
--- a/cdist/conf/explorer/cpu_cores
+++ b/cdist/conf/explorer/cpu_cores
@@ -22,7 +22,7 @@
 
 # FIXME: other system types (not linux ...)
 
-os=$("$__explorer/os")
+os=$(sh "$__explorer/os")
 case "$os" in
     "macosx")
         echo "$(sysctl -n hw.physicalcpu)"

--- a/cdist/conf/explorer/cpu_sockets
+++ b/cdist/conf/explorer/cpu_sockets
@@ -22,7 +22,7 @@
 
 # FIXME: other system types (not linux ...)
 
-os=$("$__explorer/os")
+os=$(sh "$__explorer/os")
 case "$os" in
     "macosx")
         echo "$(system_profiler SPHardwareDataType | grep "Number of Processors" | awk -F': ' '{print $2}')"

--- a/cdist/conf/explorer/lsb_codename
+++ b/cdist/conf/explorer/lsb_codename
@@ -20,7 +20,7 @@
 #
 
 set +e
-case "$($__explorer/os)" in
+case "$(sh $__explorer/os)" in
    openwrt)
       (. /etc/openwrt_release && echo "$DISTRIB_CODENAME")
    ;;

--- a/cdist/conf/explorer/lsb_description
+++ b/cdist/conf/explorer/lsb_description
@@ -20,7 +20,7 @@
 #
 
 set +e
-case "$($__explorer/os)" in
+case "$(sh $__explorer/os)" in
    openwrt)
       (. /etc/openwrt_release && echo "$DISTRIB_DESCRIPTION")
    ;;

--- a/cdist/conf/explorer/lsb_release
+++ b/cdist/conf/explorer/lsb_release
@@ -20,7 +20,7 @@
 #
 
 set +e
-case "$($__explorer/os)" in
+case "$(sh $__explorer/os)" in
    openwrt)
       (. /etc/openwrt_release && echo "$DISTRIB_RELEASE")
    ;;

--- a/cdist/conf/explorer/memory
+++ b/cdist/conf/explorer/memory
@@ -22,7 +22,7 @@
 
 # FIXME: other system types (not linux ...)
 
-os=$("$__explorer/os")
+os=$(sh "$__explorer/os")
 case "$os" in
     "macosx")
         echo "$(sysctl -n hw.memsize)/1024" | bc

--- a/cdist/conf/explorer/os_version
+++ b/cdist/conf/explorer/os_version
@@ -22,7 +22,7 @@
 #
 #
 
-case "$($__explorer/os)" in
+case "$(sh $__explorer/os)" in
    amazon)
       cat /etc/system-release
    ;;


### PR DESCRIPTION
When the filesystem is mounted with the non-executable option,
explorers are not able to call each others.

This patches allows explorers to use others by invoking them via
`sh`. Note the assumption that explorers are shell scripts.