### PR TITLE
explorer/memory: Support OpenBSD

### DIFF
--- a/cdist/conf/explorer/cpu_cores
+++ b/cdist/conf/explorer/cpu_cores
@@ -22,7 +22,7 @@
 
 # FIXME: other system types (not linux ...)
 
-os=$("$__explorer/os")
+os=$(sh "$__explorer/os")
 case "$os" in
     "macosx")
         echo "$(sysctl -n hw.physicalcpu)"

--- a/cdist/conf/explorer/cpu_sockets
+++ b/cdist/conf/explorer/cpu_sockets
@@ -22,7 +22,7 @@
 
 # FIXME: other system types (not linux ...)
 
-os=$("$__explorer/os")
+os=$(sh "$__explorer/os")
 case "$os" in
     "macosx")
         echo "$(system_profiler SPHardwareDataType | grep "Number of Processors" | awk -F': ' '{print $2}')"

--- a/cdist/conf/explorer/lsb_codename
+++ b/cdist/conf/explorer/lsb_codename
@@ -20,7 +20,7 @@
 #
 
 set +e
-case "$($__explorer/os)" in
+case "$(sh $__explorer/os)" in
    openwrt)
       (. /etc/openwrt_release && echo "$DISTRIB_CODENAME")
    ;;

--- a/cdist/conf/explorer/lsb_description
+++ b/cdist/conf/explorer/lsb_description
@@ -20,7 +20,7 @@
 #
 
 set +e
-case "$($__explorer/os)" in
+case "$(sh $__explorer/os)" in
    openwrt)
       (. /etc/openwrt_release && echo "$DISTRIB_DESCRIPTION")
    ;;

--- a/cdist/conf/explorer/lsb_release
+++ b/cdist/conf/explorer/lsb_release
@@ -20,7 +20,7 @@
 #
 
 set +e
-case "$($__explorer/os)" in
+case "$(sh $__explorer/os)" in
    openwrt)
       (. /etc/openwrt_release && echo "$DISTRIB_RELEASE")
    ;;

--- a/cdist/conf/explorer/memory
+++ b/cdist/conf/explorer/memory
@@ -22,7 +22,7 @@
 
 # FIXME: other system types (not linux ...)
 
-os=$("$__explorer/os")
+os=$(sh "$__explorer/os")
 case "$os" in
     "macosx")
         echo "$(sysctl -n hw.memsize)/1024" | bc

--- a/cdist/conf/explorer/memory
+++ b/cdist/conf/explorer/memory
@@ -2,6 +2,7 @@
 #
 # 2014 Daniel Heule  (hda at sfs.biz)
 # 2014 Thomas Oettli (otho at sfs.biz)
+# Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
 #
 # This file is part of cdist.
 #
@@ -26,6 +27,10 @@ os=$(sh "$__explorer/os")
 case "$os" in
     "macosx")
         echo "$(sysctl -n hw.memsize)/1024" | bc
+    ;;
+
+    "openbsd")
+        echo "$(sysctl -n hw.physmem) / 1048576" | bc
     ;;
 
     *)

--- a/cdist/conf/explorer/os_version
+++ b/cdist/conf/explorer/os_version
@@ -22,7 +22,7 @@
 #
 #
 
-case "$($__explorer/os)" in
+case "$(sh $__explorer/os)" in
    amazon)
       cat /etc/system-release
    ;;


### PR DESCRIPTION
Adds support to detect the amount of memory available on OpenBSD
systems.

Builds on #597 