### PR TITLE
Skip empty parameter. Fixes #599.

### DIFF
--- a/cdist/core/cdist_type.py
+++ b/cdist/core/cdist_type.py
@@ -155,7 +155,9 @@ class CdistType(object):
                                        "parameter",
                                        "required")) as fd:
                     for line in fd:
-                        parameters.append(line.strip())
+                        line = line.strip()
+                        if line:
+                            parameters.append(line)
             except EnvironmentError:
                 # error ignored
                 pass
@@ -173,7 +175,9 @@ class CdistType(object):
                                        "parameter",
                                        "required_multiple")) as fd:
                     for line in fd:
-                        parameters.append(line.strip())
+                        line = line.strip()
+                        if line:
+                            parameters.append(line)
             except EnvironmentError:
                 # error ignored
                 pass
@@ -191,7 +195,9 @@ class CdistType(object):
                                        "parameter",
                                        "optional")) as fd:
                     for line in fd:
-                        parameters.append(line.strip())
+                        line = line.strip()
+                        if line:
+                            parameters.append(line)
             except EnvironmentError:
                 # error ignored
                 pass
@@ -209,7 +215,9 @@ class CdistType(object):
                                        "parameter",
                                        "optional_multiple")) as fd:
                     for line in fd:
-                        parameters.append(line.strip())
+                        line = line.strip()
+                        if line:
+                            parameters.append(line)
             except EnvironmentError:
                 # error ignored
                 pass
@@ -227,7 +235,9 @@ class CdistType(object):
                                        "parameter",
                                        "boolean")) as fd:
                     for line in fd:
-                        parameters.append(line.strip())
+                        line = line.strip()
+                        if line:
+                            parameters.append(line)
             except EnvironmentError:
                 # error ignored
                 pass


### PR DESCRIPTION
When parameters file contain multiple empty lines then the following error occurs:
<pre>
Traceback (most recent call last):
  File "/tmp/tmp7v0e405q/90cb04f9d8b4a35c89571b1c6fb9927c/data/bin/__file", line 77, in <module>
    emulator.run()
  File "/usr/home/darko/ungleich/upstream/cdist/cdist/emulator.py", line 97, in run
    self.commandline()
  File "/usr/home/darko/ungleich/upstream/cdist/cdist/emulator.py", line 146, in commandline
    required=False, default=default)
  File "/usr/local/lib/python3.6/argparse.py", line 1348, in add_argument
    return self._add_action(action)
  File "/usr/local/lib/python3.6/argparse.py", line 1711, in _add_action
    self._optionals._add_action(action)
  File "/usr/local/lib/python3.6/argparse.py", line 1552, in _add_action
    action = super(_ArgumentGroup, self)._add_action(action)
  File "/usr/local/lib/python3.6/argparse.py", line 1362, in _add_action
    self._check_conflict(action)
  File "/usr/local/lib/python3.6/argparse.py", line 1501, in _check_conflict
    conflict_handler(action, confl_optionals)
  File "/usr/local/lib/python3.6/argparse.py", line 1510, in _handle_conflict_error
    raise ArgumentError(action, message % conflict_string)
argparse.ArgumentError: argument --: conflicting option string: --
</pre>

This fix skips empty lines when reading parameter file.
@telmich Agree?