### PR TITLE
add --minute to __cron

### DIFF
--- a/cdist/conf/type/__letsencrypt_cert/manifest
+++ b/cdist/conf/type/__letsencrypt_cert/manifest
@@ -68,4 +68,5 @@ esac
 __cron letsencrypt-certbot  \
     --user root \
     --command "$certbot_fullpath renew -q" \
-    --hour 0
+    --hour 0 \
+    --minute 47


### PR DESCRIPTION
We don't want this to run _every_ minute (default for `--minute` is `*`, so without the fix it would).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ungleich/cdist/603)
<!-- Reviewable:end -->
