### PR TITLE
__line: Support regex beginning with an hyphen (fixes #607)

### DIFF
--- a/cdist/conf/type/__line/explorer/state
+++ b/cdist/conf/type/__line/explorer/state
@@ -35,7 +35,7 @@ else
 fi
 
 # Allow missing file - thus 2>/dev/null
-if grep -q $greparg "$regex" "$file" 2>/dev/null; then
+if grep -q $greparg -- "$regex" "$file" 2>/dev/null; then
     echo present
 else
     echo absent


### PR DESCRIPTION
If `regex` begins with an hyphen, `grep` treats it as an option
and treats `file` as the regular expression. This leads to `grep`
trying to read from the standard input and making it wait infinitely.

This patch adds the missing argument breaker `--` and allows
`regex` to begin with an hyphen (provided it is called correctly).