### PR TITLE
__letsencrypt_cert: add nonparallel and make admin-email required

### DIFF
--- a/cdist/conf/type/__letsencrypt_cert/man.rst
+++ b/cdist/conf/type/__letsencrypt_cert/man.rst
@@ -17,12 +17,13 @@ REQUIRED PARAMETERS
 webroot
    The path to your webroot, as set up in your webserver config.
 
+admin-email
+   Where to send Let's Encrypt emails like "certificate needs renewal".
+
 
 OPTIONAL PARAMETERS
 -------------------
-admin-email
-   Where to send Let's Encrypt emails like "certificate needs renewal". Defaults to root@localhost.
-
+None.
 
 EXAMPLES
 --------

--- a/cdist/conf/type/__letsencrypt_cert/parameter/default/admin-email
+++ b/cdist/conf/type/__letsencrypt_cert/parameter/default/admin-email
@@ -1,1 +1,0 @@
-root@localhost

--- a/cdist/conf/type/__letsencrypt_cert/parameter/optional
+++ b/cdist/conf/type/__letsencrypt_cert/parameter/optional
@@ -1,1 +1,0 @@
-admin-email

--- a/cdist/conf/type/__letsencrypt_cert/parameter/required
+++ b/cdist/conf/type/__letsencrypt_cert/parameter/required
@@ -1,1 +1,2 @@
+admin-email
 webroot


### PR DESCRIPTION
- must be nonparallel, because certbot will complain if more than 1 instance is running (even with webroot)
- root@localhost no longer works as default admin email, so there is no good default

Merry Christmas :D

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ungleich/cdist/609)
<!-- Reviewable:end -->
