### PR TITLE
Fix gencode-remote for __package_pkgng_freebsd

### DIFF
--- a/cdist/conf/type/__package_pkgng_freebsd/gencode-remote
+++ b/cdist/conf/type/__package_pkgng_freebsd/gencode-remote
@@ -70,7 +70,7 @@ execcmd(){
          ;;
    esac
 
-   echo "$_cmd 2>&- >&-"   # Silence the output of the command
+   echo "$_cmd >/dev/null 2>&1"   # Silence the output of the command
    echo "status=\$?"
    echo "if [ \"\$status\" -ne \"0\" ]; then"
    echo "	echo \"Error: ${_cmd} exited nonzero with \$status\"'!' >&2"


### PR DESCRIPTION
When installing packages on freebsd, redirect stdout and stderr to /d…ev/null instead of closing them.

Some pre/post-install scripts rely on them being open.

(It would be better to leave them open and show the output, but I didn't
want to change the behaviour)