### PR TITLE
Add cdist.egg-info/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ __pycache__/
 MANIFEST
 dist/
 cdist/version.py
+cdist.egg-info/
 
 # sphinx build dirs, cache
 _build/


### PR DESCRIPTION
When installing the package in editable mode, cdist.egg-info/ is created
and is necessary for editable mode to work properly.