### PR TITLE
Handle stdin to __systemd_unit correctly

### DIFF
--- a/cdist/conf/type/__systemd_unit/manifest
+++ b/cdist/conf/type/__systemd_unit/manifest
@@ -34,6 +34,11 @@ if [ -z "${source}" ] && [ "${state}" != "absent" ]; then
     exit 0
 fi
 
+# stdin is not propagated automatically to sub-objects
+if [ "${source}" = "-" ]; then
+    source="${__object}/stdin"
+fi
+
 __config_file "/etc/systemd/system/${name}" \
     --mode 644 \
     --onchange "systemctl daemon-reload" \


### PR DESCRIPTION
When directly piping in the source of a systemd unit file, cdist
errored out. This is due to not propagating the stdin file to the
underlying __config_file type (which already contains code for this
case, but this has to be duplicated in __systemd_unit).

The following example thus works:

    __systemd_unit test.service --source - <<EOF
    [Service]
    ExecStart=/bin/sleep 3600
    EOF