### PR TITLE
Provide `--purge-if-absent` to __package_apt

### DIFF
--- a/cdist/conf/type/__package_apt/gencode-remote
+++ b/cdist/conf/type/__package_apt/gencode-remote
@@ -35,6 +35,11 @@ else
    target_release=""
 fi
 
+if [ -f "$__object/parameter/purge-if-absent" ]; then
+	purgeparam="--purge"
+else
+	purgeparam=""
+fi
 
 
 # FIXME: use grep directly, state is a list, not a line!
@@ -57,7 +62,7 @@ case "$state_should" in
         echo $aptget install $target_release \"$name\"
     ;;
     absent)
-        echo $aptget remove \"$name\"
+        echo $aptget remove $purgeparam \"$name\"
     ;;
     *)
         echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_apt/man.rst
+++ b/cdist/conf/type/__package_apt/man.rst
@@ -28,6 +28,9 @@ state
 target-release
     Passed on to apt-get install, see apt-get(8).
     Essentially allows you to retrieve packages from a different release
+purge-if-absent
+    If this parameter is given when state is `absent`, the package is
+    purged from the system (using `--purge`).
 
 EXAMPLES
 --------

--- a/cdist/conf/type/__package_apt/parameter/boolean
+++ b/cdist/conf/type/__package_apt/parameter/boolean
@@ -1,0 +1,1 @@
+purge-if-absent


### PR DESCRIPTION
Configuration files are not purged under Debian when the package
is deinstalled. If this parameter is given, they are deleted upon
package deinstallation.