### PR TITLE
remove `singleton` from `__apt_update_index`

### DIFF
--- a/cdist/conf/type/__apt_ppa/manifest
+++ b/cdist/conf/type/__apt_ppa/manifest
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 #
 # 2011-2016 Steven Armstrong (steven-cdist at armstrong.cc)
+# 2018 Thomas Eckert (tom at it-eckert.de)
 #
 # This file is part of cdist.
 #
@@ -27,4 +28,4 @@ require="__package/software-properties-common" \
    --source "$__type/files/remove-apt-repository" \
    --mode 0755
 
-require="$__object_name" __apt_update_index
+require="$__object_name" __apt_update_index "$__object_id"

--- a/cdist/conf/type/__apt_source/manifest
+++ b/cdist/conf/type/__apt_source/manifest
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 #
 # 2011-2013 Steven Armstrong (steven-cdist at armstrong.cc)
+# 2018 Thomas Eckert (tom at it-eckert.de)
 #
 # This file is part of cdist.
 #
@@ -51,4 +52,4 @@ __file "/etc/apt/sources.list.d/${name}.list" \
    --owner root --group root --mode 0644 \
    --state "$state"
 
-require="$__object_name" __apt_update_index
+require="__file/etc/apt/sources.list.d/${name}.list" __apt_update_index "$__object_id"

--- a/cdist/conf/type/__apt_update_index/man.rst
+++ b/cdist/conf/type/__apt_update_index/man.rst
@@ -9,6 +9,7 @@ cdist-type__apt_update_index - Update apt's package index
 DESCRIPTION
 -----------
 This cdist type runs apt-get update whenever any apt sources have changed.
+Should not be called directly (is used by `__apt_source` and `__apt_ppa`).
 
 
 REQUIRED PARAMETERS
@@ -25,7 +26,7 @@ EXAMPLES
 
 .. code-block:: sh
 
-    __apt_update_index
+    __apt_update_index "$__object_id"
 
 
 AUTHORS


### PR DESCRIPTION
If multiple apt sources were added by `__apt_source` the call of
`__apt_update_index` emitted a warning (cannot resolve dependencies) due
to conflicting auto-require.

This commit allows `__apt_update_index` to be used multiple times.

A note was added to the man-page that this should not be used directly.

The two types using `__apt_update_index` (`__apt_source` and
`__apt_ppa`) were updated accordingly.