### PR TITLE
Remove update index type dep, call update index after adding new source.

### DIFF
--- a/cdist/conf/type/__apt_source/gencode-remote
+++ b/cdist/conf/type/__apt_source/gencode-remote
@@ -1,0 +1,28 @@
+#!/bin/sh -e
+#
+# 2018 Steven Armstrong (steven-cdist at armstrong.cc)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+name="$__object_id"
+destination="/etc/apt/sources.list.d/${name}.list"
+
+if grep -q "^__file${destination}" "$__messages_in"; then
+   printf 'apt-get update || apt-get update\n'
+fi
+

--- a/cdist/conf/type/__apt_source/man.rst
+++ b/cdist/conf/type/__apt_source/man.rst
@@ -8,7 +8,8 @@ cdist-type__apt_source - Manage apt sources
 
 DESCRIPTION
 -----------
-This cdist type allows you to manage apt sources.
+This cdist type allows you to manage apt sources. It invokes index update
+internally when needed so call of index updating type is not needed.
 
 
 REQUIRED PARAMETERS
@@ -63,7 +64,7 @@ Steven Armstrong <steven-cdist--@--armstrong.cc>
 
 COPYING
 -------
-Copyright \(C) 2011-2014 Steven Armstrong. You can redistribute it
+Copyright \(C) 2011-2018 Steven Armstrong. You can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation, either version 3 of the
 License, or (at your option) any later version.

--- a/cdist/conf/type/__apt_source/manifest
+++ b/cdist/conf/type/__apt_source/manifest
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2011-2013 Steven Armstrong (steven-cdist at armstrong.cc)
+# 2011-2018 Steven Armstrong (steven-cdist at armstrong.cc)
 #
 # This file is part of cdist.
 #
@@ -50,5 +50,3 @@ __file "/etc/apt/sources.list.d/${name}.list" \
    --source "$__object/files/source.list" \
    --owner root --group root --mode 0644 \
    --state "$state"
-
-require="$__object_name" __apt_update_index


### PR DESCRIPTION
__apt_source type is updated so that it does not use __apt_update_index, but, if necessary, it calls apt-get update if new source is added.

@tom-ee  Can you test it for your case?