### PR TITLE
fix messaging for __package_update_index

### DIFF
--- a/cdist/conf/type/__package_update_index/gencode-remote
+++ b/cdist/conf/type/__package_update_index/gencode-remote
@@ -54,11 +54,12 @@ case "$type" in
              ## check if we need to update:
              if [ $currage -ge $maxage ]; then
                 echo "apt-get --quiet update"
+                echo "apt-cache updated (age was: $currage)" >> "$__messages_out"
              fi
          else
                 echo "apt-get --quiet update"
+                echo "apt-cache updated (age was: $currage)" >> "$__messages_out"
          fi
-         echo "apt-cache updated (age was: $currage)" >> "$__messages_out"
          ;;
     pacman) echo "pacman --noprogressbar --sync --refresh" ;;
     *)


### PR DESCRIPTION
The message was printed unconditionally, even if no `apt-get update` had
been running.