### PR TITLE
FreeBSD improvements

### DIFF
--- a/cdist/conf/explorer/is-freebsd-jail
+++ b/cdist/conf/explorer/is-freebsd-jail
@@ -1,0 +1,1 @@
+sysctl -n security.jail.jailed 2>/dev/null | grep "1" || true

--- a/cdist/conf/type/__hostname/gencode-remote
+++ b/cdist/conf/type/__hostname/gencode-remote
@@ -40,7 +40,7 @@ case "$os" in
             exit 0
         fi
     ;;
-    scientific|centos|openbsd)
+    scientific|centos|freebsd|openbsd)
         if [ "$name_sysconfig" = "$name_should" -a "$name_running" = "$name_should" ]; then
             exit 0
         fi
@@ -62,7 +62,7 @@ case "$os" in
         echo "printf '%s\n' '$name_should' > /etc/hostname"
         echo "hostname -F /etc/hostname"
     ;;
-    openbsd)
+    freebsd|openbsd)
         echo "hostname '$name_should'"
     ;;
     suse)

--- a/cdist/conf/type/__hostname/manifest
+++ b/cdist/conf/type/__hostname/manifest
@@ -52,6 +52,13 @@ case "$os" in
             --key HOSTNAME \
             --value "$name_should" --exact_delimiter
     ;;
+    freebsd)
+        __key_value rcconf-hostname \
+            --file /etc/rc.conf \
+            --delimiter '=' \
+            --key 'hostname' \
+            --value "$name_should"
+    ;;
     openbsd)
         echo "$name_should" | __file /etc/myname --source -
     ;;

--- a/cdist/conf/type/__start_on_boot/explorer/state
+++ b/cdist/conf/type/__start_on_boot/explorer/state
@@ -64,6 +64,10 @@ else
             state="present"
             [ -f "/etc/runlevels/${target_runlevel}/${name}" ] || state="absent"
         ;;
+        freebsd)
+            state="absent"
+            service -e | grep "/$name$" && state="present"
+        ;;
         *)
            echo "Unsupported os: $os" >&2
            exit 1

--- a/cdist/conf/type/__start_on_boot/gencode-remote
+++ b/cdist/conf/type/__start_on_boot/gencode-remote
@@ -77,6 +77,10 @@ case "$state_should" in
                     echo "update-rc.d \"$name\" defaults >/dev/null"
                 ;;
 
+                freebsd)
+                    :  # handled in manifest
+                ;;
+
                 *)
                    echo "Unsupported os: $os" >&2
                    exit 1

--- a/cdist/conf/type/__start_on_boot/manifest
+++ b/cdist/conf/type/__start_on_boot/manifest
@@ -1,0 +1,28 @@
+#!/bin/sh -e
+
+state_should="$(cat "$__object/parameter/state")"
+state_is=$(cat "$__object/explorer/state")
+name="$__object_id"
+
+# Short circuit if nothing is to be done
+[ "$state_should" = "$state_is" ] && exit 0
+
+os=$(cat "$__global/explorer/os")
+
+case "$os" in
+    freebsd)
+	if [ "$state_should" == 'present' ]; then
+	    value='YES'
+	else
+	    value='NO'
+	fi
+	__key_value rcconf-$name-enable \
+	    --file /etc/rc.conf \
+	    --key "${name}_enable" \
+	    --value "\"$value\"" \
+	    --delimiter '='
+    ;;
+    *)
+        : # handled in gencode-remote
+    ;;
+esac

--- a/cdist/conf/type/__start_on_boot/manifest
+++ b/cdist/conf/type/__start_on_boot/manifest
@@ -11,7 +11,7 @@ os=$(cat "$__global/explorer/os")
 
 case "$os" in
     freebsd)
-	if [ "$state_should" == 'present' ]; then
+	if [ "$state_should" = 'present' ]; then
 	    value='YES'
 	else
 	    value='NO'

--- a/cdist/conf/type/__sysctl/gencode-remote
+++ b/cdist/conf/type/__sysctl/gencode-remote
@@ -26,5 +26,15 @@ if [ "$value_should" = "$value_is" ]; then
    exit 0
 fi
 
+os=$(cat "$__global/explorer/os")
+case "$os" in
+    redhat|centos|ubuntu|debian|devuan|archlinux|coreos)
+        flag='-w'
+    ;;
+    frebsd)
+        flag=''
+    ;;
+esac
+
 # set the current runtime value
-printf 'sysctl -w %s="%s"\n' "$__object_id" "$value_should"
+printf 'sysctl %s %s="%s"\n' "$flag" "$__object_id" "$value_should"

--- a/cdist/conf/type/__sysctl/manifest
+++ b/cdist/conf/type/__sysctl/manifest
@@ -22,7 +22,7 @@
 os=$(cat "$__global/explorer/os")
 
 case "$os" in
-   redhat|centos|ubuntu|debian|devuan|archlinux|coreos)
+   redhat|centos|ubuntu|debian|devuan|archlinux|coreos|freebsd)
       :
    ;;
    *)


### PR DESCRIPTION
Adds FreeBSD support to `__sysctl` and `__start_on_boot`, plus adds an explorer which tells you whether the host is a FreeBSD jail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ungleich/cdist/651)
<!-- Reviewable:end -->
