### PR TITLE
__docker_stack: Use --with-registry-auth deploy option

### DIFF
--- a/cdist/conf/type/__docker_stack/gencode-remote
+++ b/cdist/conf/type/__docker_stack/gencode-remote
@@ -50,7 +50,7 @@ case "${state}" in
 		eof
 
 		docker stack deploy --compose-file "\${compose_file}" \
-			--prune ${stack}
+			--prune --with-registry-auth ${stack}
 
 		rm "\${compose_file}"
 		EOF


### PR DESCRIPTION
Without this option, Swarm agents are unable to download images from
private registries.