### PR TITLE
__docker_config: Fix config-data explorer

### DIFF
--- a/cdist/conf/type/__docker_config/explorer/config-data
+++ b/cdist/conf/type/__docker_config/explorer/config-data
@@ -18,4 +18,5 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
-docker config inspect "${__object_id:?}" | jq -r '.[0].Spec.Data' | base64 -d
+docker config inspect "${__object_id:?}" --format '{{json .Spec.Data}}' \
+	2>/dev/null | tr -d '"' | base64 -d


### PR DESCRIPTION
Before this fix, the explorer returned binary data when config did
not exist.

This commit also removes dependency on jq and sets executable flag
on the explorer file.