### PR TITLE
Fix __package_yum explorer

### DIFF
--- a/cdist/conf/type/__package_yum/explorer/pkg_version
+++ b/cdist/conf/type/__package_yum/explorer/pkg_version
@@ -27,4 +27,4 @@ else
    name="$__object_id"
 fi
 
-rpm -q --whatprovides "$name" 2>/dev/null || true
+rpm -q "$name" 2>/dev/null || rpm -q --whatprovides "$name" 2>/dev/null || true

--- a/cdist/conf/type/__package_yum/gencode-remote
+++ b/cdist/conf/type/__package_yum/gencode-remote
@@ -43,10 +43,15 @@ else
     opts="--assumeyes --quiet"
 fi
 
-not_installed="^no package provides"
+not_provided="^no package provides"
+not_installed='is not installed$'
 
-if grep -q "$not_installed" "$__object/explorer/pkg_version"; then
-    state_is="absent"
+if grep -q "$not_provided" "$__object/explorer/pkg_version"; then
+    if grep -q "$not_installed" "$__object/explorer/pkg_version"; then
+        state_is="absent"
+    else
+        state_is="present"
+    fi
 else
     state_is="present"
 fi


### PR DESCRIPTION
In case when name contains package name with exact version specified (e.g. rpm-build-4.11.3)
```
rpm -q --whatprovides "$pkg_name"
```

will tell you that no package could provide you with 'rpm-build-4.11.3',
because it's not virtual or file-provide, but exact package name.

This will lead to the installation of the package which was already installed.
It slows down manifest execution a lot.

My change will keep previous behaviour which relies on `--whatprovides` and
will fix wrong behaviour when argument is full package name with version.

Also, I've already checked the commit message which explains why `--whatprovides` 
flag was added to the command, I kind of disagree with the flag presence and would 
rather remove it, but I clearly see why it could be helpful (as in example with vim vs. 
vim-enhanced) and somewhat user-friendly.

Thanks.