### PR TITLE
add __acl: Basic wrapper around setfacl

### DIFF
--- a/cdist/conf/type/__acl/explorer/acl_is
+++ b/cdist/conf/type/__acl/explorer/acl_is
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+#
+# 2018 Ander Punnar (ander-at-kvlt-dot-ee)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+
+if [ -e "/$__object_id" ]
+then getfacl "/$__object_id" | grep -E '^((default:|)(user|group)):[a-z]' || true
+fi

--- a/cdist/conf/type/__acl/gencode-remote
+++ b/cdist/conf/type/__acl/gencode-remote
@@ -1,0 +1,81 @@
+#!/bin/sh -e
+#
+# 2018 Ander Punnar (ander-at-kvlt-dot-ee)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+
+os="$( "$__explorer/os" )"
+
+acl_path="/$__object_id"
+
+acl_is="$( cat "$__object/explorer/acl_is" )"
+
+acl_should="$( for parameter in user group
+do
+    if [ ! -f "$__object/parameter/$parameter" ]
+    then continue
+    fi
+    while read -r l
+    do
+        echo "$parameter:$l"
+
+        if [ -f "$__object/parameter/default" ]
+        then echo "default:$parameter:$l"
+        fi
+    done < "$__object/parameter/$parameter"
+done )"
+
+setfacl_exec='setfacl'
+
+if [ -f "$__object/parameter/recursive" ]
+then
+    if echo "$os" | grep -E 'macosx|netbsd|freebsd|openbsd'
+    then
+        echo "$os setfacl do not support recursive operations" >&2
+    else
+        setfacl_exec="$setfacl_exec -R"
+    fi
+fi
+
+if [ -f "$__object/parameter/remove" ]
+then
+    if echo "$os" | grep 'solaris'
+    then
+        # Solaris setfacl behaves differently.
+        # We will not support Solaris for now, because no way to test it.
+        # But adding support should be easy (use -s instead of -m on modify).
+        echo "$os setfacl do not support -x flag for ACL remove" >&2
+    else
+        echo "$acl_is" | while read -r acl
+        do
+            if echo "$acl_should" | grep -Fq "$acl"
+            then continue
+            fi
+
+            no_bits="$( echo "$acl" | sed -r 's/:[rwx-]+$//' )"
+
+            echo "$setfacl_exec -x \"$no_bits\" \"$acl_path\""
+        done
+    fi
+fi
+
+for acl in $acl_should
+do
+    if ! echo "$acl_is" | grep -Eq "^$acl"
+    then echo "$setfacl_exec -m \"$acl\" \"$acl_path\""
+    fi
+done

--- a/cdist/conf/type/__acl/gencode-remote
+++ b/cdist/conf/type/__acl/gencode-remote
@@ -18,7 +18,7 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
-os="$( "$__explorer/os" )"
+os="$( cat "$__global/explorer/os" )"
 
 acl_path="/$__object_id"
 

--- a/cdist/conf/type/__acl/man.rst
+++ b/cdist/conf/type/__acl/man.rst
@@ -1,0 +1,62 @@
+cdist-type__acl(7)
+==================
+
+NAME
+----
+cdist-type__acl - Basic wrapper around `setfacl`
+
+
+DESCRIPTION
+-----------
+ACL must be defined as 3-symbol combination, using `r`, `w`, `x` and `-`.
+
+See setfacl(1) and acl(5) for more details.
+
+
+OPTIONAL MULTIPLE PARAMETERS
+----------------------------
+user
+   Add user ACL entry.
+
+group
+   Add group ACL entry.
+
+
+BOOLEAN PARAMETERS
+------------------
+recursive
+   Operate recursively (Linux only).
+
+default
+   Add default ACL entries.
+
+remove
+   Remove undefined ACL entries (Solaris not supported).
+
+
+EXAMPLES
+--------
+
+.. code-block:: sh
+
+    __acl /srv/project \
+        --recursive \
+        --default \
+        --remove \
+        --user alice:rwx \
+        --user bob:r-x \
+        --group project-group:rwx \
+        --group some-other-group:r-x
+
+
+AUTHORS
+-------
+Ander Punnar <ander-at-kvlt-dot-ee>
+
+
+COPYING
+-------
+Copyright \(C) 2018 Ander Punnar. You can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.

--- a/cdist/conf/type/__acl/parameter/boolean
+++ b/cdist/conf/type/__acl/parameter/boolean
@@ -1,0 +1,3 @@
+recursive
+default
+remove

--- a/cdist/conf/type/__acl/parameter/optional_multiple
+++ b/cdist/conf/type/__acl/parameter/optional_multiple
@@ -1,0 +1,2 @@
+user
+group


### PR DESCRIPTION
@telmich asked:
> Why do you think recursive should be the default?

to keep things simple and because mostly, when dealing with ACL entries, you want recursive operation.

code will get very complex and error prone, if we want to differentiate between recursive and non-recursive ACL entries because `getfacl` doesn't tell (without `-R` and even with it, parsing it sanely is rather difficult, YMMV) if ACL entry is also on subdirs and files. so as first iteration I tried to get type which would cover 90% of my use cases. will see about rest of 10% in the future :-).

also about `--remove` flag - maybe some other phrase would be better, but the idea is that all destructive operations should be explicit.