### PR TITLE
Bugfix:

### DIFF
--- a/cdist/conf/type/__grafana_dashboard/manifest
+++ b/cdist/conf/type/__grafana_dashboard/manifest
@@ -9,7 +9,7 @@ case $os in
             8*|jessie)
                 apt_source_distribution=jessie
                 ;;
-            9*|ascii/ceres)
+            9*|ascii/ceres|ascii)
                 apt_source_distribution=stretch
                 ;;
             *)


### PR DESCRIPTION
- __grafana_dashboard had the wrong release name for devuan ascii

Probably they changed the output in a release, but now the release is called "ascii" only