### PR TITLE
Added --mode parameter to __apt_source type

### DIFF
--- a/cdist/conf/type/__apt_source/manifest
+++ b/cdist/conf/type/__apt_source/manifest
@@ -20,6 +20,7 @@
 
 name="$__object_id"
 state="$(cat "$__object/parameter/state")"
+mode="$(cat "$__object/parameter/mode")"
 uri="$(cat "$__object/parameter/uri")"
 
 if [ -f "$__object/parameter/distribution" ]; then
@@ -48,5 +49,5 @@ mkdir "$__object/files"
 "$__type/files/source.list.template" > "$__object/files/source.list"
 __file "/etc/apt/sources.list.d/${name}.list" \
    --source "$__object/files/source.list" \
-   --owner root --group root --mode 0644 \
+   --owner root --group root --mode "$mode" \
    --state "$state"

--- a/cdist/conf/type/__apt_source/parameter/optional
+++ b/cdist/conf/type/__apt_source/parameter/optional
@@ -2,3 +2,4 @@ state
 distribution
 component
 arch
+mode


### PR DESCRIPTION
Hi,

Was trying to change the permissions when deploying a apt source with __apt_source. But it is statically set
in the type manifest.
Added an optional --mode parameter which defaults to the previous static value 0644.

Can be useful when deploying a source which has a password in the URL and not all users on the system need to read that source URL..

Regards,

Mark Verboom