### PR TITLE
Update type `__package_update_index`

### DIFF
--- a/cdist/conf/type/__package_update_index/explorer/currage
+++ b/cdist/conf/type/__package_update_index/explorer/currage
@@ -27,6 +27,13 @@ case "$type" in
             echo 0
         fi
         ;;
+    pacman)
+        if [ -d "/var/lib/pacman/sync" ]; then
+            echo $(($(date +"%s")-$(stat --format '%Y' /var/lib/pacman/sync)))
+        else
+            echo 0
+        fi
+        ;;
     *)  echo "Your specified type ($type) is currently not supported." >&2
         echo "Please contribute an implementation for it if you can." >&2
         ;;

--- a/cdist/conf/type/__package_update_index/explorer/currage
+++ b/cdist/conf/type/__package_update_index/explorer/currage
@@ -29,6 +29,5 @@ case "$os" in
         ;;
     *)  echo "Your operating system ($os) is currently not supported by this type (${__type##*/})." >&2
         echo "Please contribute an implementation for it if you can." >&2
-        exit 1
         ;;
 esac

--- a/cdist/conf/type/__package_update_index/explorer/type
+++ b/cdist/conf/type/__package_update_index/explorer/type
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# 2018 Thomas Eckert (tom at it-eckert.de)
+# 2018 Stu Zhao (z12y12l12 at gmail.com)
 #
 # This file is part of cdist.
 #
@@ -17,17 +17,18 @@
 # You should have received a copy of the GNU General Public License
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 
-type="$($__type_explorer/type)"
-
-case "$type" in
-    apt)
-        if [ -f "/var/cache/apt/pkgcache.bin" ]; then
-            echo $(($(date +"%s")-$(stat --format '%Y' /var/cache/apt/pkgcache.bin)))
-        else
-            echo 0
-        fi
-        ;;
-    *)  echo "Your specified type ($type) is currently not supported." >&2
-        echo "Please contribute an implementation for it if you can." >&2
-        ;;
-esac
+if [ -f "$__object/parameter/type" ]; then
+    cat "$__object/parameter/type"
+else
+    # By default determine package manager based on operating system
+    os="$($__explorer/os)"
+    case "$os" in
+        amazon|scientific|centos|fedora|redhat) echo "yum" ;;
+        debian|ubuntu|devuan) echo "apt" ;;
+        archlinux) echo "pacman" ;;
+        *)
+            echo "Don't know how to manage packages on: $os" >&2
+            exit 1
+            ;;
+    esac
+fi

--- a/cdist/conf/type/__package_update_index/gencode-remote
+++ b/cdist/conf/type/__package_update_index/gencode-remote
@@ -21,26 +21,10 @@
 # Update the package index with the appropriate package manager
 #
 
-type="$__object/parameter/type"
+type=$(cat "$__object/explorer/type")
 if [ -f "$__object/parameter/maxage" ]; then
     maxage="$(cat "$__object/parameter/maxage")"
     currage="$(cat "$__object/explorer/currage")"
-fi
-
-if [ -f "$type" ]; then
-    type="$(cat "$type")"
-else
-    # By default determine package manager based on operating system
-    os="$(cat "$__global/explorer/os")"
-    case "$os" in
-        amazon|scientific|centos|fedora|redhat) type="yum" ;;
-        debian|ubuntu|devuan) type="apt" ;;
-        archlinux) type="pacman" ;;
-        *)
-            echo "Don't know how to manage packages on: $os" >&2
-            exit 1
-            ;;
-    esac
 fi
 
 if [ -n "$maxage" ] && [ "$type" != "apt" ]; then

--- a/cdist/conf/type/__package_update_index/gencode-remote
+++ b/cdist/conf/type/__package_update_index/gencode-remote
@@ -22,32 +22,33 @@
 #
 
 type=$(cat "$__object/explorer/type")
+currage="$(cat "$__object/explorer/currage")"
 if [ -f "$__object/parameter/maxage" ]; then
     maxage="$(cat "$__object/parameter/maxage")"
-    currage="$(cat "$__object/explorer/currage")"
 fi
 
-if [ -n "$maxage" ] && [ "$type" != "apt" ]; then
-    echo "ERROR: \"--maxage\" only supported for \"apt\" pkg-manager." >&2
-    exit 1
+if [ -n "$maxage" ]; then
+    if [ "$type" != "apt" -a "$type" != "pacman" ]; then
+        echo "ERROR: \"--maxage\" only supported for \"apt\" or \"pacman\" pkg-manager." >&2
+        exit 1
+    elif [ $currage -lt $maxage ]; then
+        exit 0 # no need to update
+    fi
 fi
+
 
 case "$type" in
     yum) ;;
-    apt) if [ -n "$maxage" ]; then
-             ## check if we need to update:
-             if [ $currage -ge $maxage ]; then
-                echo "apt-get --quiet update"
-                echo "apt-cache updated (age was: $currage)" >> "$__messages_out"
-             fi
-         else
-                echo "apt-get --quiet update"
-                echo "apt-cache updated (age was: $currage)" >> "$__messages_out"
-         fi
-         ;;
-    pacman) echo "pacman --noprogressbar --sync --refresh" ;;
+    apt)
+        echo "apt-get --quiet update"
+        echo "apt-cache updated (age was: $currage)" >> "$__messages_out"
+        ;;
+    pacman)
+        echo "pacman --noprogressbar --sync --refresh"
+        echo "pacman package database synced (age was: $currage)" >> "$__messages_out"
+        ;;
     *)
-        echo "Don't know how to manage packages on: $os" >&2
+        echo "Don't know how to manage packages for type: $type" >&2
         exit 1
         ;;
 esac

--- a/cdist/conf/type/__package_update_index/man.rst
+++ b/cdist/conf/type/__package_update_index/man.rst
@@ -28,8 +28,8 @@ type
     * pacman for Arch Linux
 
 maxage
-    Available for package manager apt, max time in seconds since last update.
-    Repo update is skipped if maxage is not reached yet.
+    Available for package manager apt and pacman, max time in seconds since
+    last update. Repo update is skipped if maxage is not reached yet.
 
 MESSAGES
 --------
@@ -51,6 +51,7 @@ EXAMPLES
 
     # Only update every hour:
     __package_update_index --maxage 3600 --type apt
+
     # same as above (on apt-type systems):
     __package_update_index --maxage 3600
 
@@ -58,6 +59,7 @@ AUTHORS
 -------
 | Ricardo Catalinas Jiménez <jimenezrick--@--gmail.com>
 | Thomas Eckert <tom--@--it-eckert.de>
+| Stu Zhao <z12y12l12--@--gmail.com>
 
 
 COPYING

--- a/docs/changelog
+++ b/docs/changelog
@@ -5,6 +5,7 @@ next:
 	* Type __letsencrypt_cert: Add support for devuan ascii (Darko Poljak)
 	* Type __systemd_unit: Fix minor issues and add masking unit files support (Adam Dej)
 	* Type __grafana_dashboard: Fix devuan ascii support (Dominique Roux)
+	* Type __package_update_index: Fix error when using OS not using apt (Stu Zhao)
 
 4.10.1: 2018-06-21
 	* Type __letsencrypt_cert: Fix temp file location and removal (Darko Poljak)

--- a/docs/changelog
+++ b/docs/changelog
@@ -6,6 +6,7 @@ next:
 	* Type __systemd_unit: Fix minor issues and add masking unit files support (Adam Dej)
 	* Type __grafana_dashboard: Fix devuan ascii support (Dominique Roux)
 	* Type __package_update_index: Fix error when using OS not using apt (Stu Zhao)
+	* Type __package_update_index: Support --maxage for type pacman (Stu Zhao)
 
 4.10.1: 2018-06-21
 	* Type __letsencrypt_cert: Fix temp file location and removal (Darko Poljak)


### PR DESCRIPTION
* Fixed the issue where `__package_update_index` won't run with package managers other than apt.
* Support `--maxage` parameter for Arch Linux.
* Refactored the code to handle os and package manager type correctly.