### PR TITLE
Add timestamp to log messages.

### DIFF
--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -252,6 +252,11 @@ def get_parsers():
                   'default, read hosts from stdin.'),
             dest='hostfile', required=False)
     parser['config_args'].add_argument(
+           '-P', '--timestamp',
+           help=('Timestamp log messages with the current local date and time '
+                 'in the format: YYYYMMDDHHMMSS.us.'),
+           action='store_true', dest='timestamp')
+    parser['config_args'].add_argument(
            '-p', '--parallel', nargs='?', metavar='HOST_MAX',
            type=functools.partial(check_lower_bounded_int, lower_bound=1,
                                   name="positive int"),

--- a/cdist/config.py
+++ b/cdist/config.py
@@ -175,7 +175,13 @@ class Config(object):
 
         if args.parallel or args.jobs:
             # If parallel execution then also log process id
-            cdist.log.setupParallelLogging()
+            if args.timestamp:
+                cdist.log.setupTimestampingParallelLogging()
+            else:
+                cdist.log.setupParallelLogging()
+            log = logging.getLogger("cdist")
+        elif args.timestamp:
+            cdist.log.setupTimestampingLogging()
             log = logging.getLogger("cdist")
 
         if args.parallel:

--- a/cdist/config.py
+++ b/cdist/config.py
@@ -165,24 +165,19 @@ class Config(object):
     def commandline(cls, args):
         """Configure remote system"""
 
-        # FIXME: Refactor relict - remove later
-        log = logging.getLogger("cdist")
+        if (args.parallel and args.parallel != 1) or args.jobs:
+            if args.timestamp:
+                cdist.log.setupTimestampingParallelLogging()
+            else:
+                cdist.log.setupParallelLogging()
+        elif args.timestamp:
+            cdist.log.setupTimestampingLogging()
+        log = logging.getLogger("config")
 
         # No new child process if only one host at a time.
         if args.parallel == 1:
             log.debug("Only 1 parallel process, doing it sequentially")
             args.parallel = 0
-
-        if args.parallel or args.jobs:
-            # If parallel execution then also log process id
-            if args.timestamp:
-                cdist.log.setupTimestampingParallelLogging()
-            else:
-                cdist.log.setupParallelLogging()
-            log = logging.getLogger("cdist")
-        elif args.timestamp:
-            cdist.log.setupTimestampingLogging()
-            log = logging.getLogger("cdist")
 
         if args.parallel:
             import signal

--- a/cdist/core/cdist_type.py
+++ b/cdist/core/cdist_type.py
@@ -47,7 +47,7 @@ class CdistType(object):
 
     """
 
-    log = logging.getLogger("cdist")
+    log = logging.getLogger("cdist-type")
 
     def __init__(self, base_path, name):
         self.base_path = base_path

--- a/cdist/log.py
+++ b/cdist/log.py
@@ -22,6 +22,7 @@
 
 import logging
 import sys
+import datetime
 
 
 # Define additional cdist logging levels.
@@ -95,13 +96,40 @@ class DefaultLog(logging.Logger):
         self.log(logging.TRACE, msg, *args, **kwargs)
 
 
+class TimestampingLog(DefaultLog):
+
+    def filter(self, record):
+        """Add timestamp to messages"""
+
+        super().filter(record)
+        now = datetime.datetime.now()
+        timestamp = now.strftime("%Y%m%d%H%M%S.%f")
+        record.msg = "[" + timestamp + "] " + str(record.msg)
+
+        return True
+
+
 class ParallelLog(DefaultLog):
     FORMAT = '%(levelname)s: [%(process)d]: %(message)s'
+
+
+class TimestampingParallelLog(TimestampingLog, ParallelLog):
+    pass
 
 
 def setupDefaultLogging():
     del logging.getLogger().handlers[:]
     logging.setLoggerClass(DefaultLog)
+
+
+def setupTimestampingLogging():
+    del logging.getLogger().handlers[:]
+    logging.setLoggerClass(TimestampingLog)
+
+
+def setupTimestampingParallelLogging():
+    del logging.getLogger().handlers[:]
+    logging.setLoggerClass(TimestampingParallelLog)
 
 
 def setupParallelLogging():

--- a/docs/src/man1/cdist.rst
+++ b/docs/src/man1/cdist.rst
@@ -20,7 +20,8 @@ SYNOPSIS
                  [-j [JOBS]] [-n] [-o OUT_PATH] [-R [{tar,tgz,tbz2,txz}]]
                  [-r REMOTE_OUT_DIR] [--remote-copy REMOTE_COPY]
                  [--remote-exec REMOTE_EXEC] [-I INVENTORY_DIR] [-4] [-6]
-                 [-A] [-a] [-f HOSTFILE] [-p [HOST_MAX]] [-S] [-s] [-t]
+                 [-A] [-a] [-f HOSTFILE] [-P] [-p [HOST_MAX]] [-S] [-s]
+                 [-t]
                  [host [host ...]] 
 
     cdist install [-h] [-l LOGLEVEL] [-q] [-v] [-b] [-g CONFIG_FILE]
@@ -28,7 +29,8 @@ SYNOPSIS
                   [-j [JOBS]] [-n] [-o OUT_PATH] [-R [{tar,tgz,tbz2,txz}]]
                   [-r REMOTE_OUT_DIR] [--remote-copy REMOTE_COPY]
                   [--remote-exec REMOTE_EXEC] [-I INVENTORY_DIR] [-4] [-6]
-                  [-A] [-a] [-f HOSTFILE] [-p [HOST_MAX]] [-S] [-s] [-t]
+                  [-A] [-a] [-f HOSTFILE] [-P] [-p [HOST_MAX]] [-S] [-s]
+                  [-t]
                   [host [host ...]] 
 
     cdist inventory [-h] {add-host,add-tag,del-host,del-tag,list} ...
@@ -170,6 +172,10 @@ Install command is currently in beta.
 
 **-o OUT_PATH, --out-dir OUT_PATH**
     Directory to save cdist output in.
+
+**-P, --timestamp**
+    Timestamp log messages with the current local date and time
+    in the format: YYYYMMDDHHMMSS.us.
 
 **-p [HOST_MAX], --parallel [HOST_MAX]**
     Operate on multiple hosts in parallel for specified

--- a/scripts/cdist
+++ b/scripts/cdist
@@ -69,8 +69,6 @@ if __name__ == "__main__":
         import re
         import os
 
-        log = logging.getLogger("cdist")
-
         if re.match("__", os.path.basename(sys.argv[0])):
             import cdist.emulator
             emulator = cdist.emulator.Emulator(sys.argv)
@@ -82,6 +80,7 @@ if __name__ == "__main__":
         exit_code = 2
 
     except cdist.Error as e:
+        log = logging.getLogger("cdist")
         log.error(e)
         exit_code = 1
 


### PR DESCRIPTION
With this change when timestamping is turned on (**-P, --timestamp** option) then log messages are timestamped with the current local date and time in the format **YYYYMMDDhh24mmss.us**.

Sample log lines:
```
INFO: [20180923203734.433345] 185.203.112.26: Starting configuration run
INFO: [20180923203748.876977] 185.203.112.26: Processing __myline/test
ERROR: [20180923203748.881465] 185.203.112.26: /bin/sh -......
```

And in the parallel or parallel jobs mode:
```
INFO: [4306]: [20180923204032.922092] 185.203.112.26: Starting configuration run
INFO: [4306]: [20180923204047.109844] 185.203.112.26: Processing __myline/test
ERROR: [4306]: [20180923204047.114561] 185.203.112.26: /bin/sh...
```

Debug:
```
VERBOSE: cdist: version 4.10.3-1-g6acf6f64
DEBUG: [20180923204150.561461] inventory: Host '185.203.112.26' not found, skipped
DEBUG: cdist: Base root path for target host "185.203.112.26" is "/tmp/tmpx4hk83db/90cb04f9d8b4a35c89571b1c6fb9927c"
DEBUG: [20180923204150.561812] 185.203.112.26: remote_exec for host "185.203.112.26": ssh -o User=root -o ControlPath=/tmp/tmphcvyzfqv/s  -o ControlMaster=auto  -o ControlPersist=2h
DEBUG: [20180923204150.561941] 185.203.112.26: remote_copy for host "185.203.112.26": scp -o User=root -q -o ControlPath=/tmp/tmphcvyzfqv/s  -o ControlMaster=auto  -o ControlPersist=2h
DEBUG: [20180923204150.562029] 185.203.112.26: address family: 0
DEBUG: [20180923204150.566076] 185.203.112.26: derived host_name for host "185.203.112.26": 26.112.203.185.in-addr.arpa
DEBUG: [20180923204150.568094] 185.203.112.26: derived host_fqdn for host "185.203.112.26": 26.112.203.185.in-addr.arpa
DEBUG: [20180923204150.568233] 185.203.112.26: target_host for host "185.203.112.26": ('185.203.112.26', '26.112.203.185.in-addr.arpa', '26.112.203.185.in-addr.arpa')
INFO: [20180923204150.568800] 185.203.112.26: Starting configuration run
DEBUG: [20180923204150.569237] 185.203.112.26: Checking conf_dir /usr/home/darko/ungleich/cdist/cdist/conf ...
DEBUG: [20180923204150.574617] 185.203.112.26: Checking conf_dir /home/darko/.cdist ...
DEBUG: [20180923204150.575587] 185.203.112.26: Checking conf_dir /home/darko/ungleich/dot-cdist ...
DEBUG: [20180923204150.580846] 185.203.112.26: Checking conf_dir /home/darko/ungleich/dot-cdist ...
VERBOSE: [20180923204151.479842] 185.203.112.26: Running global explorers
DEBUG: [20180923204156.133850] 185.203.112.26: Running global explorers sequentially
```