### PR TITLE
Fix SC2166 (and/or operators in test) on all manfest/gencode/explorers

### DIFF
--- a/cdist/conf/type/__ccollect_source/gencode-remote
+++ b/cdist/conf/type/__ccollect_source/gencode-remote
@@ -71,7 +71,7 @@ case "$state_should" in
             fi
             
             value_is="$(get_current_value "$attribute" "$value_should")"
-            if [ -f "$__object/files/set-attributes" -o "$value_should" != "$value_is" ]; then
+            if [ -f "$__object/files/set-attributes" ] || [ "$value_should" != "$value_is" ]; then
                 "set_$attribute" "$value_should"
             fi
         fi

--- a/cdist/conf/type/__consul_agent/manifest
+++ b/cdist/conf/type/__consul_agent/manifest
@@ -66,7 +66,7 @@ require="__directory/etc/consul" \
    __directory "$conf_dir" \
       --owner root --group "$group" --mode 750 --state "$state"
 
-if [ -f "$__object/parameter/ca-file-source" -o -f "$__object/parameter/cert-file-source" -o -f "$__object/parameter/key-file-source" ]; then
+if [ -f "$__object/parameter/ca-file-source" ] || [ -f "$__object/parameter/cert-file-source" ] || [ -f "$__object/parameter/key-file-source" ]; then
    # create directory for ssl certs
    require="__directory/etc/consul" \
       __directory /etc/consul/ssl \

--- a/cdist/conf/type/__consul_check/manifest
+++ b/cdist/conf/type/__consul_check/manifest
@@ -40,7 +40,7 @@ if [ ! -f "$__object/parameter/interval" ]; then
       fi
    done
 fi
-if [ -f "$__object/parameter/docker-container-id" -a ! -f "$__object/parameter/script" ]; then
+if [ -f "$__object/parameter/docker-container-id" ] && [ ! -f "$__object/parameter/script" ]; then
    echo "When using --docker-container-id you must also define --script." >&2
    exit 1
 fi

--- a/cdist/conf/type/__consul_service/manifest
+++ b/cdist/conf/type/__consul_service/manifest
@@ -24,15 +24,15 @@ conf_file="service_${name}.json"
 state="$(cat "$__object/parameter/state")"
 
 # Sanity checks
-if [ -f "$__object/parameter/check-script" -a -f "$__object/parameter/check-ttl" ]; then
+if [ -f "$__object/parameter/check-script" ] && [ -f "$__object/parameter/check-ttl" ]; then
    echo "Use either --check-script together with --check-interval OR --check-ttl, but not both" >&2
    exit 1
 fi
-if [ -f "$__object/parameter/check-script" -a ! -f "$__object/parameter/check-interval" ]; then
+if [ -f "$__object/parameter/check-script" ] && [ ! -f "$__object/parameter/check-interval" ]; then
    echo "When using --check-script you must also define --check-interval" >&2
    exit 1
 fi
-if [ -f "$__object/parameter/check-http" -a ! -f "$__object/parameter/check-interval" ]; then
+if [ -f "$__object/parameter/check-http" ] && [ ! -f "$__object/parameter/check-interval" ]; then
    echo "When using --check-http you must also define --check-interval" >&2
    exit 1
 fi

--- a/cdist/conf/type/__consul_template_template/manifest
+++ b/cdist/conf/type/__consul_template_template/manifest
@@ -26,11 +26,11 @@ template_dir="/etc/consul-template/template"
 require=""
 
 # Sanity checks
-if [ -f "$__object/parameter/source" -a -f "$__object/parameter/source-file" ]; then
+if [ -f "$__object/parameter/source" ] && [ -f "$__object/parameter/source-file" ]; then
    echo "Use either --source OR --source-file, but not both." >&2
    exit 1
 fi
-if [ ! -f "$__object/parameter/source" -a ! -f "$__object/parameter/source-file" ]; then
+if [ ! -f "$__object/parameter/source" ] && [ ! -f "$__object/parameter/source-file" ]; then
    echo "Either --source OR --source-file must be given." >&2
    exit 1
 fi

--- a/cdist/conf/type/__consul_watch_checks/manifest
+++ b/cdist/conf/type/__consul_watch_checks/manifest
@@ -25,7 +25,7 @@ conf_file="watch_${watch_type}_${__object_id}.json"
 state="$(cat "$__object/parameter/state")"
 
 # Sanity checks
-if [ -f "$__object/parameter/filter-service" -a -f "$__object/parameter/filter-state" ]; then
+if [ -f "$__object/parameter/filter-service" ] && [ -f "$__object/parameter/filter-state" ]; then
    echo "Use either --filter-service or --filter-state but not both." >&2
    exit 1
 fi

--- a/cdist/conf/type/__file/gencode-local
+++ b/cdist/conf/type/__file/gencode-local
@@ -23,7 +23,7 @@ destination="/$__object_id"
 state_should="$(cat "$__object/parameter/state")"
 type="$(cat "$__object/explorer/type")"
 
-[ "$state_should" = "exists" -a "$type" = "file" ] && exit 0 # nothing to do
+[ "$state_should" = "exists" ] && [ "$type" = "file" ] && exit 0 # nothing to do
 
 if [ "$state_should" = "pre-exists" ]; then
    if [ -f "$__object/parameter/source" ]; then
@@ -41,7 +41,7 @@ fi
 
 upload_file=
 create_file=
-if [ "$state_should" = "present" -o "$state_should" = "exists" ]; then
+if [ "$state_should" = "present" ] || [ "$state_should" = "exists" ]; then
    if [ ! -f "$__object/parameter/source" ]; then
       remote_stat="$(cat "$__object/explorer/stat")"
       if [ -z "$remote_stat" ]; then
@@ -70,7 +70,7 @@ if [ "$state_should" = "present" -o "$state_should" = "exists" ]; then
          fi
       fi
    fi
-   if [ "$create_file" -o "$upload_file" ]; then
+   if [ "$create_file" ] || [ "$upload_file" ]; then
       # tell gencode-remote that we created or uploaded a file and that it must
       # set all attributes no matter what the explorer retreived
       mkdir "$__object/files"

--- a/cdist/conf/type/__file/gencode-remote
+++ b/cdist/conf/type/__file/gencode-remote
@@ -72,7 +72,7 @@ case "$state_should" in
             fi
             
             value_is="$(get_current_value "$attribute" "$value_should")"
-            if [ -f "$__object/files/set-attributes" -o "$value_should" != "$value_is" ]; then
+            if [ -f "$__object/files/set-attributes" ] || [ "$value_should" != "$value_is" ]; then
                 "set_$attribute" "$value_should"
             fi
         fi

--- a/cdist/conf/type/__git/gencode-remote
+++ b/cdist/conf/type/__git/gencode-remote
@@ -35,10 +35,10 @@ owner="$(cat "$__object/parameter/owner")"
 group="$(cat "$__object/parameter/group")"
 mode="$(cat "$__object/parameter/mode")"
 
-[  "$state_should" = "$state_is" -a \
-   "$owner" = "$owner_is" -a \
-   "$group" = "$group_is" -a \
-   -n "$mode" ] && exit 0
+[  "$state_should" = "$state_is" ] && \
+[  "$owner" = "$owner_is" ] && \
+[  "$group" = "$group_is" ] && \
+[  -n "$mode" ] && exit 0
 
 case $state_should in
     present)
@@ -46,8 +46,8 @@ case $state_should in
         if [ "$state_should" != "$state_is" ]; then
             echo git clone --quiet --branch "$branch" "$source" "$destination"
         fi
-        if [ \( -n "$owner" -a "$owner_is" != "$owner" \) -o \
-             \( -n "$group" -a "$group_is" != "$group" \) ]; then
+        if { [ -n "$owner" ] && [ "$owner_is" != "$owner" ]; } || \
+           { [ -n "$group" ] && [ "$group_is" != "$group" ]; }; then
             echo chown -R "${owner}:${group}" "$destination"
         fi
         if [ -n "$mode" ]; then

--- a/cdist/conf/type/__hostname/gencode-remote
+++ b/cdist/conf/type/__hostname/gencode-remote
@@ -36,12 +36,12 @@ has_hostnamectl=$(cat "$__object/explorer/has_hostnamectl")
 #
 case "$os" in
     archlinux|debian|suse|ubuntu|devuan|coreos)
-        if [ "$name_config" = "$name_should" -a "$name_running" = "$name_should" ]; then
+        if [ "$name_config" = "$name_should" ] && [ "$name_running" = "$name_should" ]; then
             exit 0
         fi
     ;;
     scientific|centos|freebsd|openbsd)
-        if [ "$name_sysconfig" = "$name_should" -a "$name_running" = "$name_should" ]; then
+        if [ "$name_sysconfig" = "$name_should" ] && [ "$name_running" = "$name_should" ]; then
             exit 0
         fi
     ;;

--- a/cdist/conf/type/__install_partition_msdos_apply/gencode-remote
+++ b/cdist/conf/type/__install_partition_msdos_apply/gencode-remote
@@ -127,7 +127,7 @@ for object in $objects; do
    if [ "${minor}" -lt "5" ]; then
       # Primary partitions
       available_device_size=$available_size
-      if [ "$type" = "extended" -o "$type" = "5" ]; then
+      if [ "$type" = "extended" ] || [ "$type" = "5" ]; then
          # Extended partition
          available_extended_size=$partition_size
       fi

--- a/cdist/conf/type/__jail_freebsd10/gencode-remote
+++ b/cdist/conf/type/__jail_freebsd10/gencode-remote
@@ -36,7 +36,7 @@ state="$(cat "$__object/parameter/state")"
 
 started="true"
 # If the user wants the jail gone, it implies it shouldn't be started.
-[ -f "$__object/parameter/stopped" -o "$state" = "absent" ] && started="false"
+{ [ -f "$__object/parameter/stopped" ] || [ "$state" = "absent" ]; } && started="false"
 
 if [ -f "$__object/parameter/ip" ]; then
    ip="$(cat "$__object/parameter/ip")"
@@ -66,7 +66,7 @@ devfsruleset="$(cat "$__object/parameter/devfs-ruleset")"
 
 # devfs_ruleset being defined without devfs_enable being true
 #     is pointless. Treat this as an error.
-if [ -n "$devfsruleset" -a "$devfsenable" = "false" ]; then
+if [ -n "$devfsruleset" ] && [ "$devfsenable" = "false" ]; then
    exec >&2
    echo "Can't have --devfs-ruleset defined with --devfs-disable"
    exit 1

--- a/cdist/conf/type/__jail_freebsd9/gencode-remote
+++ b/cdist/conf/type/__jail_freebsd9/gencode-remote
@@ -36,7 +36,7 @@ state="$(cat "$__object/parameter/state")"
 
 started="true"
 # If the user wants the jail gone, it implies it shouldn't be started.
-[ -f "$__object/parameter/stopped" -o "$state" = "absent" ] && started="false"
+{ [ -f "$__object/parameter/stopped" ] || [ "$state" = "absent" ]; } && started="false"
 
 if [ -f "$__object/parameter/ip" ]; then
    ip="$(cat "$__object/parameter/ip")"
@@ -70,7 +70,7 @@ devfsruleset="$(cat "$__object/parameter/devfs-ruleset")"
 
 # devfs_ruleset being defined without devfs_enable being true
 #     is pointless. Treat this as an error.
-if [ -n "$devfsruleset" -a "$devfsenable" = "false" ]; then
+if [ -n "$devfsruleset" ] && [ "$devfsenable" = "false" ]; then
    exec >&2
    echo "Can't have --devfs-ruleset defined with --devfs-disable"
    exit 1

--- a/cdist/conf/type/__key_value/manifest
+++ b/cdist/conf/type/__key_value/manifest
@@ -21,7 +21,7 @@
 
 state_should="$(cat "$__object/parameter/state")"
 
-if [ "$state_should" = "present" -a ! -f "$__object/parameter/value" ]; then
+if [ "$state_should" = "present" ] && [ ! -f "$__object/parameter/value" ]; then
    echo "Missing required parameter 'value'" >&2
    exit 1
 fi 

--- a/cdist/conf/type/__line/gencode-remote
+++ b/cdist/conf/type/__line/gencode-remote
@@ -18,7 +18,7 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
-if [ -f "$__object/parameter/before" -a -f "$__object/parameter/after" ]; then
+if [ -f "$__object/parameter/before" ] && [ -f "$__object/parameter/after" ]; then
    echo "Use either --before OR --after but not both." >&2
    exit 1
 fi

--- a/cdist/conf/type/__link/gencode-remote
+++ b/cdist/conf/type/__link/gencode-remote
@@ -61,7 +61,7 @@ case "$state_should" in
     ;;
     absent)
         # only delete if it is a sym/hard link
-        if [ "$file_type" = "symlink" -o "$file_type" = "hardlink" ]; then
+        if [ "$file_type" = "symlink" ] || [ "$file_type" = "hardlink" ]; then
             printf 'rm -f "%s"\n' "$destination"
         fi
     ;;

--- a/cdist/conf/type/__package/manifest
+++ b/cdist/conf/type/__package/manifest
@@ -56,7 +56,7 @@ state="$(cat "$__object/parameter/state")"
 set -- "$@" "$__object_id" "--state" "$state"
 cd "$__object/parameter"
 for property in $(ls .); do
-   if [ "$property" != "type" -a "$property" != "state" ]; then
+   if [ "$property" != "type" ] && [ "$property" != "state" ]; then
       set -- "$@" "--$property" "$(cat "$property")"
    fi
 done

--- a/cdist/conf/type/__package_emerge/gencode-remote
+++ b/cdist/conf/type/__package_emerge/gencode-remote
@@ -38,11 +38,11 @@ fi
 pkg_version="$(cat "$__object/explorer/pkg_version")"
 if [ -z "$pkg_version" ]; then
     state_is="absent"
-elif [ -z "$version" -a $(echo "$pkg_version" | wc -l) -gt 1 ]; then
+elif [ -z "$version" ] && [ $(echo "$pkg_version" | wc -l) -gt 1 ]; then
     echo "Package name is not unique! The following packages are installed:"
     echo "$pkg_version"
     exit 1
-elif [ -n "$version" -a $(echo "$pkg_version" | cut -d " " -f 1 | sort | uniq | wc -l) -gt 1 ]; then
+elif [ -n "$version" ] && [ $(echo "$pkg_version" | cut -d " " -f 1 | sort | uniq | wc -l) -gt 1 ]; then
     echo "Package name is not unique! The following packages are installed:"
     echo "$pkg_version"
     exit 1

--- a/cdist/conf/type/__package_pkg_freebsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_freebsd/gencode-remote
@@ -66,7 +66,7 @@ cmd=""
 # FIXME: This is ugly.
 execcmd(){
 	# Set the PACKAGESITE if we're ADDing a new package
-	if [ "$1" = "add" -a -n "$pkgsite" ]; then
+	if [ "$1" = "add" ] && [ -n "$pkgsite" ]; then
 		# Use http.../All/ if we know the exact version we want, use .../Latest/ otherwise
 		pkgsite="export PACKAGESITE=${pkgsite}"
 		[ -n "$version" ] && pkgsite="${pkgsite}/All/" || pkgsite="${pkgsite}/Latest/"

--- a/cdist/conf/type/__package_pkg_openbsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_openbsd/gencode-remote
@@ -46,7 +46,7 @@ else
    name="$__object_id"
 fi
 
-if [ -n "$version" -a -n "$flavor" ]; then
+if [ -n "$version" ] && [ -n "$flavor" ]; then
    pkgid="$name-$version-$flavor"
 elif [ -n "$version" ]; then
    pkgid="$name-$version"

--- a/cdist/conf/type/__package_update_index/gencode-remote
+++ b/cdist/conf/type/__package_update_index/gencode-remote
@@ -28,7 +28,7 @@ if [ -f "$__object/parameter/maxage" ]; then
 fi
 
 if [ -n "$maxage" ]; then
-    if [ "$type" != "apt" -a "$type" != "pacman" ]; then
+    if [ "$type" != "apt" ] && [ "$type" != "pacman" ]; then
         echo "ERROR: \"--maxage\" only supported for \"apt\" or \"pacman\" pkg-manager." >&2
         exit 1
     elif [ $currage -lt $maxage ]; then

--- a/cdist/conf/type/__pyvenv/gencode-remote
+++ b/cdist/conf/type/__pyvenv/gencode-remote
@@ -29,10 +29,10 @@ owner="$(cat "$__object/parameter/owner")"
 group="$(cat "$__object/parameter/group")"
 mode="$(cat "$__object/parameter/mode")"
 
-[  "$state_should" = "$state_is" -a \
-   "$owner" = "$owner_is" -a \
-   "$group" = "$group_is" -a \
-   -n "$mode" ] && exit 0
+[  "$state_should" = "$state_is" ] && \
+[  "$owner" = "$owner_is" ] && \
+[  "$group" = "$group_is" ] && \
+[  -n "$mode" ] && exit 0
 
 destination="/$__object_id"
 venvparams="$(cat "$__object/parameter/venvparams")"
@@ -49,8 +49,8 @@ case $state_should in
         if [ "$state_should" != "$state_is" ]; then
             echo $pyvenv $venvparams "$destination"
         fi
-        if [ \( -n "$owner" -a "$owner_is" != "$owner" \) -o \
-             \( -n "$group" -a "$group_is" != "$group" \) ]; then
+        if { [ -n "$owner" ] && [ "$owner_is" != "$owner" ]; } || \
+           { [ -n "$group" ] && [ "$group_is" != "$group" ]; }; then
             echo chown -R "${owner}:${group}" "$destination"
         fi
         if [ -n "$mode" ]; then

--- a/cdist/conf/type/__ssh_authorized_keys/manifest
+++ b/cdist/conf/type/__ssh_authorized_keys/manifest
@@ -23,7 +23,7 @@ owner="$(cat "$__object/parameter/owner" 2>/dev/null || echo "$__object_id")"
 state="$(cat "$__object/parameter/state" 2>/dev/null)"
 file="$(cat "$__object/explorer/file")"
 
-if [ ! -f "$__object/parameter/noparent" -o ! -f "$__object/parameter/nofile" ]; then
+if [ ! -f "$__object/parameter/noparent" ] || [ ! -f "$__object/parameter/nofile" ]; then
    group="$(cut -d':' -f 1 "$__object/explorer/group")"
    if [ -z "$group" ]; then
       echo "Failed to get owners group from explorer." >&2


### PR DESCRIPTION
Relevant documentation: https://github.com/koalaman/shellcheck/wiki/SC2166

Apparently, the famous `-a` and `-o` are not well-defined by POSIX, and warned against by shellcheck.

shellcheck stats: 499 -> 452
relates to: #540