### PR TITLE
fix SC2148 (missing shebang) and make executable

### DIFF
--- a/cdist/conf/explorer/disks
+++ b/cdist/conf/explorer/disks
@@ -1,2 +1,3 @@
+#!/bin/sh -e
 cd /dev
 echo sd? hd? vd?

--- a/cdist/conf/explorer/disks
+++ b/cdist/conf/explorer/disks
@@ -1,3 +1,3 @@
-#!/bin/sh -e
+#!/bin/sh
 cd /dev
 echo sd? hd? vd?

--- a/cdist/conf/explorer/is-freebsd-jail
+++ b/cdist/conf/explorer/is-freebsd-jail
@@ -1,2 +1,2 @@
-#!/bin/sh -e
+#!/bin/sh
 sysctl -n security.jail.jailed 2>/dev/null | grep "1" || true

--- a/cdist/conf/explorer/is-freebsd-jail
+++ b/cdist/conf/explorer/is-freebsd-jail
@@ -1,1 +1,2 @@
+#!/bin/sh -e
 sysctl -n security.jail.jailed 2>/dev/null | grep "1" || true

--- a/cdist/conf/explorer/kernel_name
+++ b/cdist/conf/explorer/kernel_name
@@ -1,2 +1,2 @@
-#!/bin/sh -e
+#!/bin/sh
 uname -s

--- a/cdist/conf/explorer/kernel_name
+++ b/cdist/conf/explorer/kernel_name
@@ -1,1 +1,2 @@
+#!/bin/sh -e
 uname -s

--- a/cdist/conf/type/__daemontools_service/explorer/svc
+++ b/cdist/conf/type/__daemontools_service/explorer/svc
@@ -1,1 +1,2 @@
+#!/bin/sh -e
 command -v svc || true

--- a/cdist/conf/type/__daemontools_service/explorer/svc
+++ b/cdist/conf/type/__daemontools_service/explorer/svc
@@ -1,2 +1,2 @@
-#!/bin/sh -e
+#!/bin/sh
 command -v svc || true

--- a/cdist/conf/type/__go_get/explorer/go-executable
+++ b/cdist/conf/type/__go_get/explorer/go-executable
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 [ -f /etc/environment ] && . /etc/environment
 [ -f /etc/profile     ] && . /etc/profile
 go version 2>/dev/null || true

--- a/cdist/conf/type/__go_get/explorer/go-executable
+++ b/cdist/conf/type/__go_get/explorer/go-executable
@@ -1,3 +1,4 @@
+#!/bin/sh -e
 [ -f /etc/environment ] && . /etc/environment
 [ -f /etc/profile     ] && . /etc/profile
 go version 2>/dev/null || true


### PR DESCRIPTION
see <https://github.com/koalaman/shellcheck/wiki/SC2148>: `Tips depend on target shell and yours is unknown. Add a shebang.`

This adds missing shebang to all scripts and add's the missing executable flag.

RFC: I added `set -e` to these [explorer shebangs]. Is there a reason why only manifests and gencode-scripts have `set -e` and explorers do not?