### PR TITLE
fix another SC2166 (test `[ .. -a.. ]` replaced by `[ .. ] && ]`)

### DIFF
--- a/cdist/conf/explorer/machine_type
+++ b/cdist/conf/explorer/machine_type
@@ -22,7 +22,7 @@
 
 # FIXME: other system types (not linux ...)
 
-if [ -d "/proc/vz" -a ! -d "/proc/bc" ]; then
+if [ -d "/proc/vz" ] && [ ! -d "/proc/bc" ]; then
     echo openvz
     exit
 fi


### PR DESCRIPTION
one missing SC2166, <https://github.com/koalaman/shellcheck/wiki/SC2166>