### PR TITLE
fix SC2045 (use globs instead of `ls`)

### DIFF
--- a/cdist/conf/type/__config_file/manifest
+++ b/cdist/conf/type/__config_file/manifest
@@ -19,7 +19,8 @@
 #
 
 set -- "/${__object_id}"
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       source)
          source="$(cat "$__object/parameter/source")"

--- a/cdist/conf/type/__consul_agent/manifest
+++ b/cdist/conf/type/__consul_agent/manifest
@@ -84,7 +84,8 @@ echo "{"
 # parameters we define ourself
 printf '   "data_dir": "%s"\n' "$data_dir"
 
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       state|user|group|json-config) continue ;;
       ca-file-source|cert-file-source|key-file-source)

--- a/cdist/conf/type/__consul_check/manifest
+++ b/cdist/conf/type/__consul_check/manifest
@@ -50,7 +50,8 @@ fi
 echo "{"
 printf '   "check": {\n'
 printf '      "name": "%s"\n' "$name"
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       state|name) continue ;;
       *)

--- a/cdist/conf/type/__consul_service/manifest
+++ b/cdist/conf/type/__consul_service/manifest
@@ -42,7 +42,8 @@ fi
 echo "{"
 printf '   "service": {\n'
 printf '      "name": "%s"\n' "$name"
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       state|name|check-interval) continue ;;
       check-script)

--- a/cdist/conf/type/__consul_template/manifest
+++ b/cdist/conf/type/__consul_template/manifest
@@ -75,7 +75,8 @@ require="__directory/etc/consul-template" \
 
 # Generate hcl config file
 (
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       auth-password|state|ssl-*|syslog-*|version|vault-token|vault-ssl*) continue ;;
       auth-username)

--- a/cdist/conf/type/__consul_template_template/manifest
+++ b/cdist/conf/type/__consul_template_template/manifest
@@ -38,7 +38,8 @@ fi
 # Generate hcl config file
 (
 printf 'template {\n'
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       source-file)
          source="$(cat "$__object/parameter/$param")"

--- a/cdist/conf/type/__consul_watch_checks/manifest
+++ b/cdist/conf/type/__consul_watch_checks/manifest
@@ -35,7 +35,8 @@ fi
 echo "{"
 printf '   "watches": [{\n'
 printf '      "type": "%s"\n' "$watch_type"
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       state) continue ;;
       filter-*)

--- a/cdist/conf/type/__consul_watch_event/manifest
+++ b/cdist/conf/type/__consul_watch_event/manifest
@@ -29,7 +29,8 @@ state="$(cat "$__object/parameter/state")"
 echo "{"
 printf '   "watches": [{\n'
 printf '      "type": "%s"\n' "$watch_type"
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       state) continue ;;
       *)

--- a/cdist/conf/type/__consul_watch_key/manifest
+++ b/cdist/conf/type/__consul_watch_key/manifest
@@ -29,7 +29,8 @@ state="$(cat "$__object/parameter/state")"
 echo "{"
 printf '   "watches": [{\n'
 printf '      "type": "%s"\n' "$watch_type"
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       state) continue ;;
       *)

--- a/cdist/conf/type/__consul_watch_keyprefix/manifest
+++ b/cdist/conf/type/__consul_watch_keyprefix/manifest
@@ -29,7 +29,8 @@ state="$(cat "$__object/parameter/state")"
 echo "{"
 printf '   "watches": [{\n'
 printf '      "type": "%s"\n' "$watch_type"
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       state) continue ;;
       *)

--- a/cdist/conf/type/__consul_watch_nodes/manifest
+++ b/cdist/conf/type/__consul_watch_nodes/manifest
@@ -29,7 +29,8 @@ state="$(cat "$__object/parameter/state")"
 echo "{"
 printf '   "watches": [{\n'
 printf '      "type": "%s"\n' "$watch_type"
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       state) continue ;;
       *)

--- a/cdist/conf/type/__consul_watch_service/manifest
+++ b/cdist/conf/type/__consul_watch_service/manifest
@@ -29,7 +29,8 @@ state="$(cat "$__object/parameter/state")"
 echo "{"
 printf '   "watches": [{\n'
 printf '      "type": "%s"\n' "$watch_type"
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       state) continue ;;
       passingonly)

--- a/cdist/conf/type/__consul_watch_services/manifest
+++ b/cdist/conf/type/__consul_watch_services/manifest
@@ -29,7 +29,8 @@ state="$(cat "$__object/parameter/state")"
 echo "{"
 printf '   "watches": [{\n'
 printf '      "type": "%s"\n' "$watch_type"
-for param in $(ls "$__object/parameter/"); do
+cd "$__object/parameter/"
+for param in *; do
    case "$param" in
       state) continue ;;
       *)

--- a/cdist/conf/type/__jail/manifest
+++ b/cdist/conf/type/__jail/manifest
@@ -39,7 +39,7 @@ __directory ${jaildir} --parents
 
 set -- "$@" "$__object_id" "--state" "$state"
 cd "$__object/parameter"
-for property in $(ls .); do
+for property in *; do
 	set -- "$@" "--$property" "$(cat "$property")"
 done
 

--- a/cdist/conf/type/__package/manifest
+++ b/cdist/conf/type/__package/manifest
@@ -55,7 +55,7 @@ state="$(cat "$__object/parameter/state")"
 
 set -- "$@" "$__object_id" "--state" "$state"
 cd "$__object/parameter"
-for property in $(ls .); do
+for property in *; do
    if [ "$property" != "type" ] && [ "$property" != "state" ]; then
       set -- "$@" "--$property" "$(cat "$property")"
    fi

--- a/cdist/conf/type/__user/gencode-remote
+++ b/cdist/conf/type/__user/gencode-remote
@@ -52,7 +52,7 @@ shorten_property() {
 if [ "$state" = "present" ]; then
     cd "$__object/parameter"
     if grep -q "^${name}:" "$__object/explorer/passwd"; then
-       for property in $(ls .); do
+       for property in *; do
           new_value="$(cat "$property")"
           unset current_value
 
@@ -113,7 +113,7 @@ if [ "$state" = "present" ]; then
        fi
     else
         echo add >> "$__messages_out"
-        for property in $(ls .); do
+        for property in *; do
             [ "$property" = "state" ] && continue
             [ "$property" = "remove-home" ] && continue
             new_value="$(cat "$property")"


### PR DESCRIPTION
`Iterating over ls output is fragile. Use globs.` <https://github.com/koalaman/shellcheck/wiki/SC2045>

This also unifies the 2 styles that were in place ...