### PR TITLE
Fix SC2069 (wrong stdout/stderr redirect order)

### DIFF
--- a/cdist/conf/explorer/machine
+++ b/cdist/conf/explorer/machine
@@ -22,6 +22,6 @@
 #
 #
 
-if command -v uname 2>&1 >/dev/null; then
+if command -v uname >/dev/null 2>&1 ; then
    uname -m
 fi


### PR DESCRIPTION
In the original order, stderr was connected to the old stdout
(terminal). This was _probably_ not intended. The new order fixes this
by first connecting stdout to /dev/null and then attaching stderr to
that as well.

references #540.