### PR TITLE
Disable SC2016 check.

### DIFF
--- a/cdist/conf/type/__docker_compose/gencode-remote
+++ b/cdist/conf/type/__docker_compose/gencode-remote
@@ -24,8 +24,9 @@ state="$(cat "$__object/parameter/state")"
 
 if [ "${state}" = "present" ]; then
     # Download docker-compose file
-        echo 'curl -L "https://github.com/docker/compose/releases/download/'"${version}"'/docker-compose-$(uname -s)-$(uname -m)" -o /tmp/docker-compose'
-        echo 'mv /tmp/docker-compose /usr/local/bin/docker-compose'
+    #shellcheck disable=SC2016
+    echo 'curl -L "https://github.com/docker/compose/releases/download/'"${version}"'/docker-compose-$(uname -s)-$(uname -m)" -o /tmp/docker-compose'
+    echo 'mv /tmp/docker-compose /usr/local/bin/docker-compose'
     # Change permissions
     echo 'chmod +x /usr/local/bin/docker-compose'
 fi

--- a/cdist/conf/type/__golang_from_vendor/manifest
+++ b/cdist/conf/type/__golang_from_vendor/manifest
@@ -1,3 +1,4 @@
 #!/bin/sh -e
 
+# shellcheck disable=SC2016
 __line go_in_path --line 'export PATH=/usr/local/go/bin:$PATH' --file /etc/profile

--- a/cdist/conf/type/__package_emerge/explorer/pkg_version
+++ b/cdist/conf/type/__package_emerge/explorer/pkg_version
@@ -32,4 +32,5 @@ else
    name="$__object_id"
 fi
 
+# shellcheck disable=SC2016
 equery -q l -F '$cp $fullversion' "$name" || true

--- a/cdist/conf/type/__rvm_gemset/explorer/state
+++ b/cdist/conf/type/__rvm_gemset/explorer/state
@@ -25,7 +25,9 @@ if [ ! -e "~$user/.rvm/scripts/rvm" ] ; then
    exit 0
 fi
 
+# shellcheck disable=SC2016
 if su - "$user" -c 'source ~/.rvm/scripts/rvm; rvm list strings | grep -q "^$ruby\$"'; then
+    # shellcheck disable=SC2016
     if su - "$user" -c 'source ~/.rvm/scripts/rvm; rvm use "$ruby" > /dev/null; rvm gemset list strings | cut -f 1 -d " " | grep -q "^$gemsetname\$"'; then
       echo "present"
       exit 0

--- a/cdist/conf/type/__staged_file/gencode-local
+++ b/cdist/conf/type/__staged_file/gencode-local
@@ -62,7 +62,9 @@ fetch_file() {
 }
 
 fetch_and_prepare_file() {
+   # shellcheck disable=SC2016
    printf 'tmpdir="$(mktemp -d --tmpdir="/tmp" "%s")"\n' "${__type##*/}.XXXXXXXXXX"
+   # shellcheck disable=SC2016
    printf 'cd "$tmpdir"\n'
    # shellcheck disable=SC2059
    printf "$fetch_command > \"%s\"\n" "$source" "$source_file_name"
@@ -70,6 +72,7 @@ fetch_and_prepare_file() {
    # shellcheck disable=SC2059
    printf "$prepare_command > \"%s\"\n" "$source_file_name" "$stage_file"
    printf 'cd - >/dev/null\n'
+   # shellcheck disable=SC2016
    printf 'rm -rf "$tmpdir"\n'
 }
 


### PR DESCRIPTION
SC2016

Expressions don't expand in single quotes, use double quotes for that.

https://github.com/koalaman/shellcheck/wiki/SC2016

But here this is intended.