### PR TITLE
shellcheck on /files/ scripts.

### DIFF
--- a/cdist/conf/type/__consul_agent/files/consul.sysv-debian
+++ b/cdist/conf/type/__consul_agent/files/consul.sysv-debian
@@ -31,9 +31,11 @@
 ### END INIT INFO
 
 if [ -f "/etc/default/consul" ]; then
+    # shellcheck disable=SC1091
     . /etc/default/consul
 fi
 
+# shellcheck disable=SC1091
 . /lib/lsb/init-functions
 
 NAME=consul

--- a/cdist/conf/type/__consul_agent/files/consul.sysv-redhat
+++ b/cdist/conf/type/__consul_agent/files/consul.sysv-redhat
@@ -11,51 +11,52 @@
 # pidfile: /var/run/consul/pidfile
 
 # Source function library.
+
 # shellcheck disable=SC1091
 . /etc/init.d/functions
 NAME=consul
 CONSUL=/usr/local/bin/consul
-CONFIG=/etc/$NAME/conf.d
-PID_FILE=/var/run/$NAME/pidfile
-LOG_FILE=/var/log/$NAME
+CONFIG="/etc/$NAME/conf.d"
+PID_FILE="/var/run/$NAME/pidfile"
+LOG_FILE="/var/log/$NAME"
 
 # shellcheck disable=SC1090
-[ -e /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
-export GOMAXPROCS=${GOMAXPROCS:-2}
+[ -e "/etc/sysconfig/$NAME" ] && . "/etc/sysconfig/$NAME"
+export GOMAXPROCS="${GOMAXPROCS:-2}"
 
-mkdir -p /var/run/$NAME
-chown consul:consul /var/run/$NAME
-chmod 2770 /var/run/$NAME
+mkdir -p "/var/run/$NAME"
+chown consul:consul "/var/run/$NAME"
+chmod 2770 "/var/run/$NAME"
 
 
 start() {
-   printf "Starting %s" "$NAME: "
+   printf "Starting %s: " "$NAME"
    daemon --user=consul \
       --pidfile="$PID_FILE" \
       "$CONSUL" agent -pid-file="$PID_FILE" -config-dir "$CONFIG" >> "$LOG_FILE" &
    retcode=$?
-   touch /var/lock/subsys/$NAME
-   return $retcode
+   touch "/var/lock/subsys/$NAME"
+   return "$retcode"
 }
 
 stop() {
-   printf "Shutting down %s" "$NAME: "
-   killproc -p "$PID_FILE" $NAME
+   printf "Shutting down %s: " "$NAME"
+   killproc -p "$PID_FILE" "$NAME"
    retcode=$?
-   rm -f /var/lock/subsys/$NAME
-   return $retcode
+   rm -f "/var/lock/subsys/$NAME"
+   return "$retcode"
 }
 
 case "$1" in
    start)
-      if status -p "$PID_FILE" $NAME >/dev/null; then
+      if status -p "$PID_FILE" "$NAME" >/dev/null; then
          echo "$NAME already running"
       else
          start
       fi
    ;;
    stop)
-      if status -p "$PID_FILE" $NAME >/dev/null; then
+      if status -p "$PID_FILE" "$NAME" >/dev/null; then
          stop
       else
          echo "$NAME not running"
@@ -65,25 +66,25 @@ case "$1" in
       "$CONSUL" info
    ;;
    status)
-      status -p "$PID_FILE" $NAME
+      status -p "$PID_FILE" "$NAME"
       exit $?
    ;;
    restart)
-      if status -p "$PID_FILE" $NAME >/dev/null; then
+      if status -p "$PID_FILE" "$NAME" >/dev/null; then
          stop
       fi
       start
    ;;
    reload)
-      if status -p "$PID_FILE" $NAME >/dev/null; then
+      if status -p "$PID_FILE" "$NAME" >/dev/null; then
          kill -HUP "$(cat "$PID_FILE")"
       else
          echo "$NAME not running"
       fi
    ;;
    condrestart)
-      if [ -f /var/lock/subsys/$NAME ]; then
-         if status -p "$PID_FILE" $NAME >/dev/null; then
+      if [ -f "/var/lock/subsys/$NAME" ]; then
+         if status -p "$PID_FILE" "$NAME" >/dev/null; then
             stop
          fi
          start

--- a/cdist/conf/type/__consul_agent/files/consul.sysv-redhat
+++ b/cdist/conf/type/__consul_agent/files/consul.sysv-redhat
@@ -11,6 +11,7 @@
 # pidfile: /var/run/consul/pidfile
 
 # Source function library.
+# shellcheck disable=SC1091
 . /etc/init.d/functions
 NAME=consul
 CONSUL=/usr/local/bin/consul
@@ -18,6 +19,7 @@ CONFIG=/etc/$NAME/conf.d
 PID_FILE=/var/run/$NAME/pidfile
 LOG_FILE=/var/log/$NAME
 
+# shellcheck disable=SC1090
 [ -e /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
 export GOMAXPROCS=${GOMAXPROCS:-2}
 
@@ -27,7 +29,7 @@ chmod 2770 /var/run/$NAME
 
 
 start() {
-   echo -n "Starting $NAME: "
+   printf "Starting %s" "$NAME: "
    daemon --user=consul \
       --pidfile="$PID_FILE" \
       "$CONSUL" agent -pid-file="$PID_FILE" -config-dir "$CONFIG" >> "$LOG_FILE" &
@@ -37,7 +39,7 @@ start() {
 }
 
 stop() {
-   echo -n "Shutting down $NAME: "
+   printf "Shutting down %s" "$NAME: "
    killproc -p "$PID_FILE" $NAME
    retcode=$?
    rm -f /var/lock/subsys/$NAME
@@ -46,14 +48,14 @@ stop() {
 
 case "$1" in
    start)
-      if $(status -p "$PID_FILE" $NAME >/dev/null); then
+      if status -p "$PID_FILE" $NAME >/dev/null; then
          echo "$NAME already running"
       else
          start
       fi
    ;;
    stop)
-      if $(status -p "$PID_FILE" $NAME >/dev/null); then
+      if status -p "$PID_FILE" $NAME >/dev/null; then
          stop
       else
          echo "$NAME not running"
@@ -67,21 +69,21 @@ case "$1" in
       exit $?
    ;;
    restart)
-      if $(status -p "$PID_FILE" $NAME >/dev/null); then
+      if status -p "$PID_FILE" $NAME >/dev/null; then
          stop
       fi
       start
    ;;
    reload)
-      if $(status -p "$PID_FILE" $NAME >/dev/null); then
-         kill -HUP `cat $PID_FILE`
+      if status -p "$PID_FILE" $NAME >/dev/null; then
+         kill -HUP "$(cat "$PID_FILE")"
       else
          echo "$NAME not running"
       fi
    ;;
    condrestart)
       if [ -f /var/lock/subsys/$NAME ]; then
-         if $(status -p "$PID_FILE" $NAME >/dev/null); then
+         if status -p "$PID_FILE" $NAME >/dev/null; then
             stop
          fi
          start

--- a/cdist/conf/type/__consul_template/files/consul-template.sysv
+++ b/cdist/conf/type/__consul_template/files/consul-template.sysv
@@ -10,74 +10,75 @@
 # pidfile: /var/run/consul-template/pidfile
 
 # Source function library.
+
 # shellcheck disable=SC1091
 . /etc/init.d/functions
 NAME=consul-template
 CONSUL_TEMPLATE=/usr/local/bin/consul-template
-CONFIG=/etc/$NAME/conf.d
-PID_FILE=/var/run/$NAME/pidfile
-LOG_FILE=/var/log/$NAME
+CONFIG="/etc/$NAME/conf.d"
+PID_FILE="/var/run/$NAME/pidfile"
+LOG_FILE="/var/log/$NAME"
 
 # shellcheck disable=SC1090
-[ -e /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
-export CONSUL_TEMPLATE_LOG=${CONSUL_TEMPLATE_LOG:-info}
-export GOMAXPROCS=${GOMAXPROCS:-2}
+[ -e "/etc/sysconfig/$NAME" ] && . "/etc/sysconfig/$NAME"
+export CONSUL_TEMPLATE_LOG="${CONSUL_TEMPLATE_LOG:-info}"
+export GOMAXPROCS="${GOMAXPROCS:-2}"
 
-mkdir -p /var/run/$NAME
+mkdir -p "/var/run/$NAME"
 
 start() {
-   printf "Starting %s" "$NAME: "
+   printf "Starting %s: " "$NAME"
    daemon --pidfile="$PID_FILE" \
       "$CONSUL_TEMPLATE" -config "$CONFIG" >> "$LOG_FILE" 2>&1 &
-   echo $! > "$PID_FILE"
+   echo "$!" > "$PID_FILE"
    retcode=$?
-   touch /var/lock/subsys/$NAME
-   return $retcode
+   touch "/var/lock/subsys/$NAME"
+   return "$retcode"
 }
 
 stop() {
-   printf "Shutting down %s" "$NAME: "
-   killproc -p $PID_FILE $CONSUL_TEMPLATE
+   printf "Shutting down %s: " "$NAME"
+   killproc -p "$PID_FILE" "$CONSUL_TEMPLATE"
    retcode=$?
-   rm -f /var/lock/subsys/$NAME
-   return $retcode
+   rm -f "/var/lock/subsys/$NAME"
+   return "$retcode"
 }
 
 case "$1" in
    start)
-      if status -p "$PID_FILE" $NAME >/dev/null; then
+      if status -p "$PID_FILE" "$NAME" >/dev/null; then
          echo "$NAME already running"
       else
          start
       fi
    ;;
    stop)
-      if status -p "$PID_FILE" $NAME >/dev/null; then
+      if status -p "$PID_FILE" "$NAME" >/dev/null; then
          stop
       else
          echo "$NAME not running"
       fi
    ;;
    status)
-      status -p "$PID_FILE" $NAME
+      status -p "$PID_FILE" "$NAME"
       exit $?
    ;;
    restart)
-      if status -p "$PID_FILE" $NAME >/dev/null; then
+      if status -p "$PID_FILE" "$NAME" >/dev/null; then
          stop
       fi
       start
    ;;
    reload)
-      if status -p "$PID_FILE" $NAME >/dev/null; then
+      if status -p "$PID_FILE" "$NAME" >/dev/null; then
           kill -HUP "$(cat "$PID_FILE")"
       else
          echo "$NAME not running"
       fi
    ;;
    condrestart)
-      if [ -f /var/lock/subsys/$NAME ]; then
-         if status -p "$PID_FILE" $NAME >/dev/null; then
+      if [ -f "/var/lock/subsys/$NAME" ]; then
+         if status -p "$PID_FILE" "$NAME" >/dev/null; then
             stop
          fi
          start

--- a/cdist/conf/type/__consul_template/files/consul-template.sysv
+++ b/cdist/conf/type/__consul_template/files/consul-template.sysv
@@ -10,6 +10,7 @@
 # pidfile: /var/run/consul-template/pidfile
 
 # Source function library.
+# shellcheck disable=SC1091
 . /etc/init.d/functions
 NAME=consul-template
 CONSUL_TEMPLATE=/usr/local/bin/consul-template
@@ -17,6 +18,7 @@ CONFIG=/etc/$NAME/conf.d
 PID_FILE=/var/run/$NAME/pidfile
 LOG_FILE=/var/log/$NAME
 
+# shellcheck disable=SC1090
 [ -e /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
 export CONSUL_TEMPLATE_LOG=${CONSUL_TEMPLATE_LOG:-info}
 export GOMAXPROCS=${GOMAXPROCS:-2}
@@ -24,7 +26,7 @@ export GOMAXPROCS=${GOMAXPROCS:-2}
 mkdir -p /var/run/$NAME
 
 start() {
-   echo -n "Starting $NAME: "
+   printf "Starting %s" "$NAME: "
    daemon --pidfile="$PID_FILE" \
       "$CONSUL_TEMPLATE" -config "$CONFIG" >> "$LOG_FILE" 2>&1 &
    echo $! > "$PID_FILE"
@@ -34,7 +36,7 @@ start() {
 }
 
 stop() {
-   echo -n "Shutting down $NAME: "
+   printf "Shutting down %s" "$NAME: "
    killproc -p $PID_FILE $CONSUL_TEMPLATE
    retcode=$?
    rm -f /var/lock/subsys/$NAME
@@ -43,14 +45,14 @@ stop() {
 
 case "$1" in
    start)
-      if $(status -p "$PID_FILE" $NAME >/dev/null); then
+      if status -p "$PID_FILE" $NAME >/dev/null; then
          echo "$NAME already running"
       else
          start
       fi
    ;;
    stop)
-      if $(status -p "$PID_FILE" $NAME >/dev/null); then
+      if status -p "$PID_FILE" $NAME >/dev/null; then
          stop
       else
          echo "$NAME not running"
@@ -61,21 +63,21 @@ case "$1" in
       exit $?
    ;;
    restart)
-      if $(status -p "$PID_FILE" $NAME >/dev/null); then
+      if status -p "$PID_FILE" $NAME >/dev/null; then
          stop
       fi
       start
    ;;
    reload)
-      if $(status -p "$PID_FILE" $NAME >/dev/null); then
-         kill -HUP `cat $PID_FILE`
+      if status -p "$PID_FILE" $NAME >/dev/null; then
+          kill -HUP "$(cat "$PID_FILE")"
       else
          echo "$NAME not running"
       fi
    ;;
    condrestart)
       if [ -f /var/lock/subsys/$NAME ]; then
-         if $(status -p "$PID_FILE" $NAME >/dev/null); then
+         if status -p "$PID_FILE" $NAME >/dev/null; then
             stop
          fi
          start

--- a/cdist/conf/type/__daemontools/files/init.d-svscan
+++ b/cdist/conf/type/__daemontools/files/init.d-svscan
@@ -23,9 +23,9 @@ fi
 
 case "$1" in
     start)
-        echo -n "Starting daemontools: "
-        if [ ! `pidof svscan` ]; then
-                echo -n "svscan "
+        printf "Starting daemontools: "
+        if [ ! "$(pidof svscan)" ]; then
+                printf "svscan "
                 env - PATH="$PATH" svscan /service 2>&1 | setuidgid daemon multilog t /var/log/svscan &
                 echo "."
         else
@@ -33,23 +33,23 @@ case "$1" in
         fi
         ;;
     stop)
-        echo -n "Stopping daemontools: "
-        if [ `pidof svscan` ]; then
-                echo -n "svscan"
-                while [ `pidof svscan` ]; do
-                     kill `pidof svscan`
-                     echo -n "."
+        printf "Stopping daemontools: "
+        if [ "$(pidof svscan)" ]; then
+                printf "svscan"
+                while [ "$(pidof svscan)" ]; do
+                     kill "$(pidof svscan)"
+                     printf "."
                 done
         fi
-        echo -n " services"
-        for i in `ls -d /service/*`; do
-                svc -dx $i
-                echo -n "."
+        printf " services"
+        for i in /service/*; do
+                svc -dx "$i"
+                printf "."
         done
-        echo -n " logging "
-        for i in `ls -d /service/*/log`; do
-                svc -dx $i
-                echo -n "."
+        printf " logging "
+        for i in /service/*/log; do
+                svc -dx "$i"
+                printf "."
         done
         echo ""
         ;;

--- a/cdist/conf/type/__daemontools/files/init.d-svscan
+++ b/cdist/conf/type/__daemontools/files/init.d-svscan
@@ -24,7 +24,7 @@ fi
 case "$1" in
     start)
         printf "Starting daemontools: "
-        if [ ! "$(pidof svscan)" ]; then
+        if  ! pidof svscan > /dev/null 2>&1; then
                 printf "svscan "
                 env - PATH="$PATH" svscan /service 2>&1 | setuidgid daemon multilog t /var/log/svscan &
                 echo "."
@@ -34,11 +34,16 @@ case "$1" in
         ;;
     stop)
         printf "Stopping daemontools: "
-        if [ "$(pidof svscan)" ]; then
+        pids="$(pidof svscan)"
+        if [ -n "${pids}" ]
+        then
                 printf "svscan"
-                while [ "$(pidof svscan)" ]; do
-                     kill "$(pidof svscan)"
-                     printf "."
+                while [ -n "${pids}" ]
+                do
+                    # shellcheck disable=SC2086
+                    kill ${pids}
+                    printf "."
+                    pids="$(pidof svscan)"
                 done
         fi
         printf " services"

--- a/cdist/conf/type/__install_config/files/remote/copy
+++ b/cdist/conf/type/__install_config/files/remote/copy
@@ -41,8 +41,8 @@ log "@: $*"
 log "code: $code"
 
 # copy files into chroot
-# code should be split on spaces
+# __default_remote_copy and code should be split
 # shellcheck disable=SC2086
-"$__default_remote_copy" $code
+$__default_remote_copy $code
 
 log "-----"

--- a/cdist/conf/type/__install_config/files/remote/copy
+++ b/cdist/conf/type/__install_config/files/remote/copy
@@ -37,10 +37,10 @@ code="$(echo "$@" | sed "s|$target_host:|$target_host:$chroot|g")"
 
 log "target_host: $target_host"
 log "chroot: $chroot"
-log "@: $@"
+log "@: $*"
 log "code: $code"
 
 # copy files into chroot
-$__default_remote_copy $code
+"$__default_remote_copy" "$code"
 
 log "-----"

--- a/cdist/conf/type/__install_config/files/remote/copy
+++ b/cdist/conf/type/__install_config/files/remote/copy
@@ -41,6 +41,8 @@ log "@: $*"
 log "code: $code"
 
 # copy files into chroot
-"$__default_remote_copy" "$code"
+# code should be split on spaces
+# shellcheck disable=SC2086
+"$__default_remote_copy" $code
 
 log "-----"

--- a/cdist/conf/type/__install_config/files/remote/exec
+++ b/cdist/conf/type/__install_config/files/remote/exec
@@ -36,6 +36,7 @@ shift
 
 # escape ' with '"'"'
 code="$(echo "$@" | sed -e "s/'/'\"'\"'/g")"
+# shellcheck disable=SC2089
 code="chroot $chroot sh -e -c '$code'"
 
 log "target_host: $target_host"
@@ -44,6 +45,8 @@ log "@: $*"
 log "code: $code"
 
 # Run the code
-"$__default_remote_exec" "$target_host" "$code"
+# code should be split on spaces
+# shellcheck disable=SC2086,SC2090
+"$__default_remote_exec" "$target_host" $code
 
 log "-----"

--- a/cdist/conf/type/__install_config/files/remote/exec
+++ b/cdist/conf/type/__install_config/files/remote/exec
@@ -40,10 +40,10 @@ code="chroot $chroot sh -e -c '$code'"
 
 log "target_host: $target_host"
 log "chroot: $chroot"
-log "@: $@"
+log "@: $*"
 log "code: $code"
 
 # Run the code
-$__default_remote_exec $target_host $code
+"$__default_remote_exec" "$target_host" "$code"
 
 log "-----"

--- a/cdist/conf/type/__install_config/files/remote/exec
+++ b/cdist/conf/type/__install_config/files/remote/exec
@@ -45,8 +45,8 @@ log "@: $*"
 log "code: $code"
 
 # Run the code
-# code should be split on spaces
+# __default_remote_exec and code should be split
 # shellcheck disable=SC2086,SC2090
-"$__default_remote_exec" "$target_host" $code
+$__default_remote_exec "$target_host" $code
 
 log "-----"

--- a/cdist/conf/type/__install_partition_msdos_apply/files/lib.sh
+++ b/cdist/conf/type/__install_partition_msdos_apply/files/lib.sh
@@ -1,9 +1,11 @@
+#!/bin/sh
+
 die() {
-   echo "[__install_partition_msdos_apply] $@" >&2
+   echo "[__install_partition_msdos_apply] $*" >&2
    exit 1
 }
 debug() {
-   #echo "[__install_partition_msdos_apply] $@" >&2
+   #echo "[__install_partition_msdos_apply] $*" >&2
    :
 }
 
@@ -12,7 +14,7 @@ fdisk_command() {
    cmd="$2"
 
    debug fdisk_command "running fdisk command '${cmd}' on device ${device}"
-   printf "${cmd}\nw\n" | fdisk -c -u "$device"
+   printf '%s\nw\n' "${cmd}" | fdisk -c -u "$device"
    ret=$?
    # give disk some time
    sleep 1
@@ -23,14 +25,14 @@ create_disklabel() {
    device=$1
 
    debug create_disklabel "creating new msdos disklabel"
-   fdisk_command ${device} "o"
+   fdisk_command "${device}" "o"
    return $?
 }
 
 toggle_bootable() {
    device="$1"
    minor="$2"
-   fdisk_command ${device} "a\n${minor}\n"
+   fdisk_command "${device}" "a\\n${minor}\\n"
    return $?
 }
 
@@ -41,28 +43,28 @@ create_partition() {
   type="$4"
   primary_count="$5"
 
-  if [ "$type" = "extended" -o "$type" = "5" ]; then
+  if [ "$type" = "extended" ] || [ "$type" = "5" ]; then
     # Extended partition
-    primary_extended="e\n"
-    first_minor="${minor}\n"
+    primary_extended='e\n'
+    first_minor="${minor}\\n"
     [ "${minor}" = "4" ] && first_minor=""
-    type_minor="${minor}\n"
+    type_minor="${minor}\\n"
     [ "${minor}" = "1" ] && type_minor=""
     type="5"
   elif [ "${minor}" -lt "5" ]; then
-    primary_extended="p\n"
-    first_minor="${minor}\n"
+    primary_extended='p\n'
+    first_minor="${minor}\\n"
     [ "${minor}" = "4" ] && first_minor=""
-    type_minor="${minor}\n"
+    type_minor="${minor}\\n"
     [ "${minor}" = "1" ] && type_minor=""
   else
     # Logical partitions
-    first_minor="${minor}\n"
-    type_minor="${minor}\n"
-    primary_extended="l\n"
+    first_minor="${minor}\\n"
+    type_minor="${minor}\\n"
+    primary_extended='l\n'
     [ "$primary_count" -gt "3" ] && primary_extended=""
   fi
   [ -n "${size}" ] && size="+${size}M"
-  fdisk_command ${device} "n\n${primary_extended}${first_minor}\n${size}\nt\n${type_minor}${type}\n"
+  fdisk_command "${device}" "n\\n${primary_extended}${first_minor}\\n${size}\\nt\\n${type_minor}${type}\\n"
   return $?
 }

--- a/cdist/conf/type/__iptables_apply/files/init-script
+++ b/cdist/conf/type/__iptables_apply/files/init-script
@@ -24,14 +24,14 @@ case $1 in
         iptables-save > "$status"
 
         # Apply our ruleset
-        cd "$basedir"
+        cd "$basedir" || exit
         count="$(ls -1 | wc -l)"
 
         # Only do something if there are rules
         if [ "$count" -ge 1 ]; then
             for rule in *; do
                 echo "Applying iptables rule $rule ..."
-                iptables $(cat "$rule")
+                iptables "$(cat "$rule")"
             done
         fi
     ;;

--- a/cdist/conf/type/__iptables_apply/files/init-script
+++ b/cdist/conf/type/__iptables_apply/files/init-script
@@ -25,7 +25,7 @@ case $1 in
 
         # Apply our ruleset
         cd "$basedir" || exit
-        count="$(ls -1 | wc -l)"
+        count="$(find . ! -name . -prune | wc -l)"
 
         # Only do something if there are rules
         if [ "$count" -ge 1 ]; then

--- a/cdist/conf/type/__iptables_apply/files/init-script
+++ b/cdist/conf/type/__iptables_apply/files/init-script
@@ -31,7 +31,9 @@ case $1 in
         if [ "$count" -ge 1 ]; then
             for rule in *; do
                 echo "Applying iptables rule $rule ..."
-                iptables "$(cat "$rule")"
+                # Rule should be split.
+                # shellcheck disable=SC2046
+                iptables $(cat "$rule")
             done
         fi
     ;;

--- a/cdist/conf/type/__key_value/files/remote_script.sh
+++ b/cdist/conf/type/__key_value/files/remote_script.sh
@@ -1,19 +1,21 @@
 #!/bin/sh
 
-export key="$(cat "$__object/parameter/key" 2>/dev/null \
+key="$(cat "$__object/parameter/key" 2>/dev/null \
    || echo "$__object_id")"
-export state="$(cat "$__object/parameter/state")"
+state="$(cat "$__object/parameter/state")"
 
 file="$(cat "$__object/parameter/file")"
 
-export delimiter="$(cat "$__object/parameter/delimiter")"
-export value="$(cat "$__object/parameter/value" 2>/dev/null \
+delimiter="$(cat "$__object/parameter/delimiter")"
+value="$(cat "$__object/parameter/value" 2>/dev/null \
    || echo "__CDIST_NOTSET__")"
+export key state delimiter value
 if [ -f "$__object/parameter/exact_delimiter" ]; then
-    export exact_delimiter=1
+    exact_delimiter=1
 else
-    export exact_delimiter=0
+    exact_delimiter=0
 fi
+export exact_delimiter
 
 tmpfile=$(mktemp "${file}.cdist.XXXXXXXXXX")
 # preserve ownership and permissions by copying existing file over tmpfile

--- a/cdist/conf/type/__yum_repo/files/repo.template
+++ b/cdist/conf/type/__yum_repo/files/repo.template
@@ -43,7 +43,7 @@ for key in baseurl gpgkey; do
    if [ -f "$__object/parameter/$key" ]; then
       printf '%s=' "$key"
       prefix=''
-      while read line; do
+      while read -r line; do
          printf '%s%s\n' "$prefix" "$line"
          prefix='   '
       done < "$__object/parameter/$key"


### PR DESCRIPTION
Here is another set of shellcheck fixes.
This one is for shell scripts under **/files/** type directories.

@asteven @thriqon @tom-ee Please review.

@asteven Please review **__install_config/files/remote/{copy,exec}** and **__install_partition_msdos_apply/files/lib.sh** changes in detail.

@AnotherKamila I am mentioning you because this changes your init scripts for daemontools type.