### PR TITLE
Provide shellchecking travis-yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ matrix:
 
 python: "3.6"
 
+git:
+  depth: false
+
 install:
   - |
       if [ "$TARGET" = "shellcheck" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,11 @@ script:
       fi
   - |
       if [ "$TARGET" = "docs" ]; then
+        git branch master origin/master # for reference docs
         make docs
       fi
   - |
       if [ "$TARGET" = "test" ]; then
+        git branch master origin/master # for version information
         make test
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,43 @@
-language: shell
+language: python
 sudo: false
 
+matrix:
+  include:
+    - name: "Shellcheck"
+      env: TARGET=shellcheck
+    - name: "Unit Tests"
+      env: TARGET=test
+    - name: "Docs"
+      env: TARGET=docs
+
+python: "3.6"
+
 install:
-  - export scversion="v0.4.7" # or "stable", or "latest"
-  - wget "https://storage.googleapis.com/shellcheck/shellcheck-${scversion}.linux.x86_64.tar.xz"
-  - tar --xz -xvf shellcheck-"${scversion}".linux.x86_64.tar.xz
-  - cp shellcheck-"${scversion}"/shellcheck /tmp/
+  - |
+      if [ "$TARGET" = "shellcheck" ]; then
+        export scversion="v0.4.7" # or "stable", or "latest"
+        wget "https://storage.googleapis.com/shellcheck/shellcheck-${scversion}.linux.x86_64.tar.xz"
+        tar --xz -xvf shellcheck-"${scversion}".linux.x86_64.tar.xz
+        cp shellcheck-"${scversion}"/shellcheck /tmp/
+        /tmp/shellcheck --version # for reference
+      fi
+  - |
+      if [ "$TARGET" = "docs" ]; then
+        pip install sphinx sphinx_rtd_theme
+      fi
 
 script:
-  - /tmp/shellcheck --version # for reference
-  - PATH=/tmp:$PATH make shellcheck | tee shellcheck-results.log
-  - test "$(wc -c < shellcheck-results.log)" -eq 0
+  - |
+      if [ "$TARGET" = "shellcheck" ]; then
+        export PATH=/tmp:$PATH
+        make shellcheck | tee shellcheck-results.log
+        test "$(wc -c < shellcheck-results.log)" -eq 0
+      fi
+  - |
+      if [ "$TARGET" = "docs" ]; then
+        make docs
+      fi
+  - |
+      if [ "$TARGET" = "test" ]; then
+        make test
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: shell
+sudo: false
+
+install:
+  - export scversion="v0.4.7" # or "stable", or "latest"
+  - wget "https://storage.googleapis.com/shellcheck/shellcheck-${scversion}.linux.x86_64.tar.xz"
+  - tar --xz -xvf shellcheck-"${scversion}".linux.x86_64.tar.xz
+  - cp shellcheck-"${scversion}"/shellcheck /tmp/
+
+script:
+  - /tmp/shellcheck --version # for reference
+  - PATH=/tmp:$PATH make shellcheck | tee shellcheck-results.log
+  - test "$(wc -c < shellcheck-results.log)" -eq 0

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ distclean: clean
 pub:
 	git push --mirror
 
-test:
+test: $(PYTHON_VERSION)
 	$(helper) $@
 
 test-remote:


### PR DESCRIPTION
Explicitly install version 0.4.7, as version 0.4.6 displayed some
errors. 0.4.6 is pre-installed in the Travis images right now.

I've enabled Travis on my fork: https://travis-ci.org/thriqon/cdist. After merging, the upstream repo has to be enabled as well, otherwise, this change won't have any effect.