### PR TITLE
Improve  user type

### DIFF
--- a/cdist/conf/type/__user/gencode-remote
+++ b/cdist/conf/type/__user/gencode-remote
@@ -135,10 +135,10 @@ elif [ "$state" = "absent" ]; then
     if grep -q "^${name}:" "$__object/explorer/passwd"; then
         #user exists, but state != present, so delete it
         if [ -f "$__object/parameter/remove-home" ]; then
-            printf "userdel -r %s >/dev/null 2>&1\n" "${name}"
+            printf "userdel -r '%s' >/dev/null 2>&1\n" "${name}"
 	    echo "userdel -r" >> "$__messages_out"
         else
-            printf "userdel %s >/dev/null 2>&1\n" "${name}"
+            printf "userdel '%s' >/dev/null 2>&1\n" "${name}"
 	    echo "userdel" >> "$__messages_out"
         fi
     fi

--- a/cdist/conf/type/__user/gencode-remote
+++ b/cdist/conf/type/__user/gencode-remote
@@ -3,6 +3,7 @@
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2011 Nico Schottelius (nico-cdist at schottelius.org)
 # 2013 Daniel Heule (hda at sfs.biz)
+# 2018 Thomas Eckert (tom at it-eckert.de)
 #
 # This file is part of cdist.
 #
@@ -130,7 +131,7 @@ if [ "$state" = "present" ]; then
           echo useradd "$@" "$name"
        fi
     fi
-else
+elif [ "$state" = "absent" ]; then
     if grep -q "^${name}:" "$__object/explorer/passwd"; then
         #user exists, but state != present, so delete it
         if [ -f "$__object/parameter/remove-home" ]; then
@@ -139,4 +140,6 @@ else
             echo userdel "${name}"
         fi
     fi
+else
+    echo "Invalid state $state" >&2
 fi

--- a/cdist/conf/type/__user/gencode-remote
+++ b/cdist/conf/type/__user/gencode-remote
@@ -135,10 +135,10 @@ elif [ "$state" = "absent" ]; then
     if grep -q "^${name}:" "$__object/explorer/passwd"; then
         #user exists, but state != present, so delete it
         if [ -f "$__object/parameter/remove-home" ]; then
-            echo userdel -r "${name}"
+            printf "userdel -r %s >/dev/null 2>&1\n" "${name}"
 	    echo "userdel -r" >> "$__messages_out"
         else
-            echo userdel "${name}"
+            printf "userdel %s >/dev/null 2>&1\n" "${name}"
 	    echo "userdel" >> "$__messages_out"
         fi
     fi

--- a/cdist/conf/type/__user/gencode-remote
+++ b/cdist/conf/type/__user/gencode-remote
@@ -135,10 +135,10 @@ elif [ "$state" = "absent" ]; then
     if grep -q "^${name}:" "$__object/explorer/passwd"; then
         #user exists, but state != present, so delete it
         if [ -f "$__object/parameter/remove-home" ]; then
-            printf "userdel -r '%s' >/dev/null 2>&1\n" "${name}"
+            printf "userdel -r '%s' >/dev/null 2>&1\\n" "${name}"
 	    echo "userdel -r" >> "$__messages_out"
         else
-            printf "userdel '%s' >/dev/null 2>&1\n" "${name}"
+            printf "userdel '%s' >/dev/null 2>&1\\n" "${name}"
 	    echo "userdel" >> "$__messages_out"
         fi
     fi

--- a/cdist/conf/type/__user/gencode-remote
+++ b/cdist/conf/type/__user/gencode-remote
@@ -136,8 +136,10 @@ elif [ "$state" = "absent" ]; then
         #user exists, but state != present, so delete it
         if [ -f "$__object/parameter/remove-home" ]; then
             echo userdel -r "${name}"
+	    echo "userdel -r" >> "$__messages_out"
         else
             echo userdel "${name}"
+	    echo "userdel" >> "$__messages_out"
         fi
     fi
 else

--- a/cdist/conf/type/__user/man.rst
+++ b/cdist/conf/type/__user/man.rst
@@ -60,6 +60,11 @@ mod
 add
     New user added
 
+userdel -r
+    If user was deleted with homedir
+
+userdel
+    If user was deleted (keeping homedir)
 
 EXAMPLES
 --------


### PR DESCRIPTION
3 improvements for __user:

* redirect stdout and error of `userdel` to get rid of annoying output
* handle typos in `--state`-parameter gracefully (previously `--state presetn` or similar typos would have delete the user
* message user removal (w/ and w/o remove-home)

manpage updated accordingly.