### PR TITLE
Fix __group type failing with --gid

### DIFF
--- a/cdist/conf/type/__group/gencode-remote
+++ b/cdist/conf/type/__group/gencode-remote
@@ -30,9 +30,9 @@ state="$(cat "$__object/parameter/state")"
 # Use short option names for portability
 shorten_property() {
    case "$1" in
-      gid) echo -- "-g";;
-      password) echo -- "-p";;
-      system) echo -- "-r";;
+      gid) echo " -g";;
+      password) echo " -p";;
+      system) echo " -r";;
    esac
 }
 


### PR DESCRIPTION
The command `echo -- -g` prints `-- -g` so the generated `groupadd` command
was syntactically incorrect and failing. Solution was to remove `--` since
echo command does not understand it, and add instead an extra space before
`-g` to avoid echo interpreting it as a flag.