### PR TITLE
type: Add new type __ping

### DIFF
--- a/cdist/conf/type/__ping/gencode-remote
+++ b/cdist/conf/type/__ping/gencode-remote
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+#
+# Copyright (C) 2018 Olliver Schinagl <oliver@schinagl.nl>
+#
+# SPDX-License-Identifier: GPL-3.0+
+#
+
+set -eu
+
+echo "echo 'pong'"
+
+exit 0

--- a/cdist/conf/type/__ping/man.rst
+++ b/cdist/conf/type/__ping/man.rst
@@ -1,0 +1,43 @@
+cdist-type__ping(7)
+==================================
+
+NAME
+----
+cdist-type__ping - Try to connect to host and return 'pong' on success
+
+
+DESCRIPTION
+-----------
+A simple type which tries to connect to a remote host and runs a simple command
+to ensure everything is working.
+
+
+REQUIRED PARAMETERS
+-------------------
+None.
+
+
+OPTIONAL PARAMETERS
+-------------------
+None.
+
+
+EXAMPLES
+--------
+
+.. code-block:: sh
+
+    __ping
+
+
+AUTHORS
+-------
+Olliver Schinagl <oliver--@--schinagl.nl>
+
+
+COPYING
+-------
+Copyright \(C) 2018 Schinagl. You can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.


### PR DESCRIPTION
When starting with cdist, the documentation and examples can be
overwheliming. Further more, sometimes one would only want to do a
simple test to see if the basics are working. One such example currently
is to create a simple remote file. While this is a nice and simple
example, an even simpler example would be to just see if we can 'ping'
the host.

Other configuration management tools also seem to have this as a basic
starting command.

This thus allows to do:
echo __ping | cdist config --initial-manifest - <host>

as the most basic, most simple command to 'test' things with, without
having lingering files to boot.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>