### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true


### PR DESCRIPTION
With editorconfig, users have their editor setup automatically for the
codestyle of this project. While some editors have support for editor
config built in by default, others require a plugin. In both cases, it
is fully optional.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>