### PR TITLE
Update .gitignore to more broadly ignore vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,21 @@
 # -vim
-.*.swp
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
 
 # Ignore generated manpages
 docs/src/.marker


### PR DESCRIPTION
As per https://github.com/github/gitignore/blob/master/Global/Vim.gitignore

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>