### PR TITLE
All package types send messages upon installation/removal

### DIFF
--- a/cdist/conf/type/__package_emerge/gencode-remote
+++ b/cdist/conf/type/__package_emerge/gencode-remote
@@ -64,9 +64,11 @@ fi
 case "$state_should" in
    present)
         echo "emerge '$name' &>/dev/null || exit 1"
+        echo "installed" >> "$__messages_out"
         ;;
    absent)
         echo "emerge -C '$name' &>/dev/null || exit 1"
+        echo "removed" >> "$__messages_out"
         ;;
    *)
         echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_emerge/gencode-remote
+++ b/cdist/conf/type/__package_emerge/gencode-remote
@@ -39,12 +39,12 @@ pkg_version="$(cat "$__object/explorer/pkg_version")"
 if [ -z "$pkg_version" ]; then
     state_is="absent"
 elif [ -z "$version" ] && [ "$(echo "$pkg_version" | wc -l)" -gt 1 ]; then
-    echo "Package name is not unique! The following packages are installed:"
-    echo "$pkg_version"
+    echo "Package name is not unique! The following packages are installed:" >&2
+    echo "$pkg_version" >&2
     exit 1
 elif [ -n "$version" ] && [ "$(echo "$pkg_version" | cut -d " " -f 1 | sort | uniq | wc -l)" -gt 1 ]; then
-    echo "Package name is not unique! The following packages are installed:"
-    echo "$pkg_version"
+    echo "Package name is not unique! The following packages are installed:" >&2
+    echo "$pkg_version" >&2
     exit 1
 else
     state_is="present"

--- a/cdist/conf/type/__package_emerge_dependencies/gencode-remote
+++ b/cdist/conf/type/__package_emerge_dependencies/gencode-remote
@@ -6,10 +6,11 @@ flaggie_installed="$(cat "$__object/explorer/flaggie_installed")"
 if [ "${gentoolkit_installed}" != "true" ]; then
     # emerge app-portage/gentoolkit
     echo "emerge app-portage/gentoolkit &> /dev/null || exit 1"
+    echo "installed app-portage/gentoolkit" >> "$__messages_out"
 fi
 
 if [ "${flaggie_installed}" != "true" ]; then
     # emerge app-portage/flaggie
     echo "emerge app-portage/flaggie &> /dev/null || exit 1"
+    echo "installed app-portage/flaggie" >> "$__messages_out"
 fi
-

--- a/cdist/conf/type/__package_luarocks/gencode-remote
+++ b/cdist/conf/type/__package_luarocks/gencode-remote
@@ -43,9 +43,11 @@ fi
 case "$state_should" in
     present)
         echo "luarocks install '$name'"
+        echo "installed" >> "$__messages_out"
     ;;
     absent)
         echo "luarocks remove '$name'"
+        echo "removed" >> "$__messages_out"
     ;;
     *)
         echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_opkg/gencode-remote
+++ b/cdist/conf/type/__package_opkg/gencode-remote
@@ -43,12 +43,14 @@ esac
 case "$state_should" in
     present)
         if [ "$present" = "notpresent" ]; then
-            echo opkg --verbosity=0 update
+            echo "opkg --verbosity=0 update"
         fi
         echo "opkg --verbosity=0 install '$name'"
+        echo "installed" >> "$__messages_out"
     ;;
     absent)
         echo "opkg --verbosity=0 remove '$name'"
+        echo "removed" >> "$__messages_out"
     ;;
     *)
         echo "Unknown state: ${state_should}" >&2

--- a/cdist/conf/type/__package_pacman/gencode-remote
+++ b/cdist/conf/type/__package_pacman/gencode-remote
@@ -46,9 +46,11 @@ fi
 case "$state_should" in
    present)
          echo "pacman --needed --noconfirm --noprogressbar -S '$name'"
+         echo "installed" >> "$__messages_out"
    ;;
    absent)
          echo "pacman --noconfirm --noprogressbar -R '$name'"
+         echo "removed" >> "$__messages_out"
    ;;
    *)
       echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_pip/gencode-remote
+++ b/cdist/conf/type/__package_pip/gencode-remote
@@ -57,6 +57,7 @@ case "$state_should" in
         else
             echo $pip install -q "$name"
         fi
+        echo "installed" >> "$__messages_out"
     ;;
     absent)
         if [ "$runas" ]
@@ -65,6 +66,7 @@ case "$state_should" in
         else
             echo $pip uninstall -q -y "$name"
         fi
+        echo "removed" >> "$__messages_out"
     ;;
     *)
         echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_pkg_freebsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_freebsd/gencode-remote
@@ -39,7 +39,7 @@ assert ()                 #  If condition false,
 		# shellcheck disable=SC2039
 		echo "File \"$0\", line $lineno, called by $(caller 0)"
 		exit $E_ASSERT_FAILED
-	fi  
+	fi
 }
 
 # Debug
@@ -89,6 +89,7 @@ if [ -n "$curr_version" ]; then	# PKG *is* installed
 			cmd="${rm_cmd} ${name}-${curr_version}"
 		fi
 		execcmd "remove" "${cmd}"
+		echo "removed" >> "$__messages_out"
 		exit 0
 	else	# Should be installed
 		if [ -n "$version" ]; then	# Want a specific version
@@ -102,6 +103,7 @@ if [ -n "$curr_version" ]; then	# PKG *is* installed
 				execcmd "remove" "${cmd}"
 				cmd="${add_cmd} -r ${name}-${version}"
 				execcmd "add" "${cmd}"
+				echo "installed" >> "$__messages_out"
 			fi
 		else	# Don't care what version to use
 			exit 0
@@ -120,6 +122,7 @@ else	# PKG *isn't* installed
 			cmd="${cmd}-${version}"
 		fi
 		execcmd "add" "${cmd}"
+		echo "installed" >> "$__messages_out"
 		exit 0
 	fi
 fi

--- a/cdist/conf/type/__package_pkg_openbsd/explorer/pkg_state
+++ b/cdist/conf/type/__package_pkg_openbsd/explorer/pkg_state
@@ -1,7 +1,5 @@
 #!/bin/sh
 #
-# 2011 Andi Brönnimann (andi-cdist at v-net.ch)
-# Copyright 2017, Philippe Gregoire <pg@pgregoire.xyz>
 # Copyright 2018, Takashi Yoshi <takashi@yoshi.email>
 #
 # This file is part of cdist.
@@ -20,19 +18,32 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 #
-# Retrieve the version of a package - parsed pkg_info output
+# Retrieve the status of a package - parsed pkg_info output
 #
 
-if [ -f "$__object/parameter/name" ]; then
-   name="$(cat "$__object/parameter/name")"
+if [ -f "${__object}/parameter/name" ]
+then
+	pkgid="$(cat "${__object}/parameter/name")"
 else
-   name="$__object_id"
+	pkgid="${__object_id}"
 fi
 
-# Extract version number from pkg_info.
-# Refer to packages-specs(7) for more information regarding the format.
+if [ -f "${__object}/parameter/version" ]
+then
+	pkgid="${pkgid}-$(cat "${__object}/parameter/version")"
+fi
 
-# ATTENTION: If $name is just a stem (e.g. "php" or "python"), there may be
-#            multiple results. pkg_info prints a line for each version.
+if [ -f "${__object}/parameter/flavor" ]
+then
+	# If a flavor but no version is given we need to add another -,
+	# otherwise pkg_info confuses the flavor with the version.
+	[ -f "${__object}/parameter/version" ] || pkgid="${pkgid}-"
 
-pkg_info -q -I "inst:$name" | sed -e 's/^\([^-]*-\)*\([0-9][^-]*\).*$/\2/'
+	pkgid="${pkgid}-$(cat "${__object}/parameter/flavor")"
+fi
+
+
+pkg_info -q -I "inst:${pkgid}" >/dev/null 2>&1 \
+	&& echo 'present' || echo 'absent'
+
+exit 0

--- a/cdist/conf/type/__package_pkg_openbsd/explorer/pkg_version
+++ b/cdist/conf/type/__package_pkg_openbsd/explorer/pkg_version
@@ -19,7 +19,7 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 #
-# Retrieve the status of a package - parsed dpkg output
+# Retrieve the status of a package - parsed pkg_info output
 #
 
 if [ -f "$__object/parameter/name" ]; then
@@ -28,5 +28,10 @@ else
    name="$__object_id"
 fi
 
-#TODO: Is there a better way?
-pkg_info | grep "^$name-[0-9]" | sed 's|.*\(-[0-9][0-9.]*\).*|\1|' | sed 's/-//'
+# Extract version number from pkg_info.
+# Refer to packages-specs(7) for more information regarding the format.
+
+# ATTENTION: If $name is just a stem (e.g. "php" or "python"), there may be
+#            multiple results. pkg_info prints a line for each version.
+
+pkg_info -q -I "inst:$name" | sed -e 's/^\([^-]*-\)*\([0-9][^-]*\).*$/\2/'

--- a/cdist/conf/type/__package_pkg_openbsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_openbsd/gencode-remote
@@ -62,15 +62,15 @@ state_should="$(cat "$__object/parameter/state")"
 
 pkg_version="$(cat "$__object/explorer/pkg_version")"
 
-if [ -f "$__object/parameter/pkg_path" ]; then                                  
-  pkg_path="$(cat "$__object/parameter/pkg_path")"                              
+if [ -f "$__object/parameter/pkg_path" ]; then
+  pkg_path="$(cat "$__object/parameter/pkg_path")"
 else
   has_installurl=$(cat "${__object}/explorer/has_installurl")
   if [ Xyes != X"${has_installurl}" ]; then
       # there is no default PKG_PATH, try to provide one
       pkg_path="ftp://ftp.openbsd.org/pub/OpenBSD/$os_version/packages/$machine/"
   fi
-fi                                                                              
+fi
 
 if [ "$pkg_version" ]; then
     state_is="present"
@@ -99,11 +99,12 @@ if [ \$? -ne 0 ]; then
     echo "Error: \$status"
     exit 1
 fi
+echo "installed" >> "$__messages_out"
 eof
     ;;
 
     absent)
-        # use this because pkg_add doesn't properly handle errors
+        # use this because pkg_delete doesn't properly handle errors
         cat << eof
 status=\$(pkg_delete "$pkgopts" "$pkgid")
 pkg_info | grep "^${name}.*${version}.*${flavor}" > /dev/null 2>&1
@@ -117,6 +118,7 @@ if [ \$? -eq 0 ]; then
     echo "Error: \$status"
     exit 1
 fi
+echo "removed" >> "$__messages_out"
 eof
    ;;
    *)

--- a/cdist/conf/type/__package_pkg_openbsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_openbsd/gencode-remote
@@ -96,7 +96,7 @@ if [ \$? -ne 0 ]; then
     if [ -z "\${status}" ]; then
       status="Failed to add package, uncaught exception."
     fi
-    echo "Error: \$status"
+    echo "Error: \$status" >&2
     exit 1
 fi
 echo "installed" >> "$__messages_out"
@@ -115,7 +115,7 @@ if [ \$? -eq 0 ]; then
     if [ -z "\${status}" ]; then
       status="Failed to remove package, uncaught exception."
     fi
-    echo "Error: \$status"
+    echo "Error: \$status" >&2
     exit 1
 fi
 echo "removed" >> "$__messages_out"

--- a/cdist/conf/type/__package_pkg_openbsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_openbsd/gencode-remote
@@ -2,6 +2,7 @@
 #
 # 2011 Andi Brönnimann (andi-cdist at v-net.ch)
 # 2012 Nico Schottelius (nico-cdist at schottelius.org)
+# 2018 Takashi Yoshi <takashi@yoshi.email>
 #
 # This file is part of cdist.
 #
@@ -72,12 +73,7 @@ else
   fi
 fi
 
-if [ "$pkg_version" ]; then
-    state_is="present"
-else
-    state_is="absent"
-fi
-
+state_is="$(cat "$__object/explorer/pkg_state")"
 [ "$state_is" = "$state_should" ] && exit 0
 
 case "$state_should" in
@@ -88,7 +84,7 @@ if [ X != X"${pkg_path}" ]; then
     PKG_PATH="${pkg_path}"; export PKG_PATH
 fi
 status=\$(pkg_add "$pkgopts" "$pkgid" 2>&1)
-pkg_info | grep "^${name}.*${version}.*${flavor}" > /dev/null 2>&1
+pkg_info -q -I "inst:$pkgid" | grep -q "^${name}-${version}.*${flavor}$" 2>/dev/null
 
 # We didn't find the package in the list of 'installed packages', so it failed
 # This is necessary because pkg_add doesn't return properly
@@ -107,7 +103,7 @@ eof
         # use this because pkg_delete doesn't properly handle errors
         cat << eof
 status=\$(pkg_delete "$pkgopts" "$pkgid")
-pkg_info | grep "^${name}.*${version}.*${flavor}" > /dev/null 2>&1
+pkg_info -q -I "inst:$pkgid" | grep -q "^${name}-${version}.*${flavor}" 2>/dev/null
 
 # We found the package in the list of 'installed packages'
 # This would indicate that pkg_delete failed, send the output of pkg_delete

--- a/cdist/conf/type/__package_pkg_openbsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_openbsd/gencode-remote
@@ -23,102 +23,98 @@
 # Manage packages with pkg on OpenBSD
 #
 
-# Debug
-# exec >&2
-# set -x
+os_version=$(cat "${__global}/explorer/os_version")
+machine=$(cat "${__global}/explorer/machine")
 
-os_version="$(cat "$__global/explorer/os_version")"
-machine="$(cat "$__global/explorer/machine")"
-
-if [ -f "$__object/parameter/version" ]; then
-	version="$(cat "$__object/parameter/version")"
+if [ -f "${__object}/parameter/version" ]; then
+	version=$(cat "${__object}/parameter/version")
 fi
 
-if [ -f "$__object/parameter/flavor" ]; then
-	flavor="$(cat "$__object/parameter/flavor")"
+if [ -f "${__object}/parameter/flavor" ]; then
+	flavor=$(cat "${__object}/parameter/flavor")
 fi
 
-# do not show progress bar
-pkgopts="-x"
+# Do not show progress bar
+pkgopts='-x'
 
-if [ -f "$__object/parameter/name" ]; then
-   name=$(cat "$__object/parameter/name")
+name="${__object_id}"
+if [ -f "${__object}/parameter/name" ]; then
+	name=$(cat "${__object}/parameter/name")
+fi
+
+if [ -n "${version}" ] && [ -n "${flavor}" ]; then
+	pkgid="${name}-${version}-${flavor}"
+elif [ -n "${version}" ]; then
+	pkgid="${name}-${version}"
+elif [ -f "${__object}/parameter/flavor" ]; then
+	pkgid="${name}--${flavor}"
 else
-   name="$__object_id"
+	pkgid="${name}"
 fi
 
-if [ -n "$version" ] && [ -n "$flavor" ]; then
-   pkgid="$name-$version-$flavor"
-elif [ -n "$version" ]; then
-   pkgid="$name-$version"
-elif [ -n "$flavor" ]; then
-   pkgid="$name--$flavor"
-elif [ -f "$__object/parameter/flavor" ]; then
-   pkgid="$name--"
+state_should=$(cat "${__object}/parameter/state")
+
+pkg_version=$(cat "${__object}/explorer/pkg_version")
+
+if [ -f "${__object}/parameter/pkg_path" ]; then
+	pkg_path=$(cat "${__object}/parameter/pkg_path")
 else
-   pkgid="$name"
+	has_installurl=$(cat "${__object}/explorer/has_installurl")
+	if [ 'yes' != "${has_installurl}" ]; then
+		# There is no default PKG_PATH, try to provide one
+		pkg_path="ftp://ftp.openbsd.org/pub/OpenBSD/${os_version}/packages/${machine}/"
+	fi
 fi
 
-state_should="$(cat "$__object/parameter/state")"
+state_is=$(cat "${__object}/explorer/pkg_state")
+[ "${state_is}" = "${state_should}" ] && exit 0
 
-pkg_version="$(cat "$__object/explorer/pkg_version")"
+case "${state_should}" in
+	present)
+		if [ -n "${pkg_path}" ]; then
+			echo "export PKG_PATH='${pkg_path}'"
+		fi
 
-if [ -f "$__object/parameter/pkg_path" ]; then
-  pkg_path="$(cat "$__object/parameter/pkg_path")"
-else
-  has_installurl=$(cat "${__object}/explorer/has_installurl")
-  if [ Xyes != X"${has_installurl}" ]; then
-      # there is no default PKG_PATH, try to provide one
-      pkg_path="ftp://ftp.openbsd.org/pub/OpenBSD/$os_version/packages/$machine/"
-  fi
+		# Use this because pkg_add doesn't properly handle errors
+		cat << EOF
+status=\$(pkg_add ${pkgopts} '${pkgid}' 2>&1 || true)
+
+if ! pkg_info -q -I 'inst:${pkgid}' | grep -q '^${name}-${version}.*${flavor}$' 2>/dev/null
+then
+	# We didn't find the package in the list of 'installed packages', so it failed.
+	# This is necessary because pkg_add doesn't return properly
+
+	if [ -z "\${status}" ]; then
+		status='Failed to add package, uncaught exception.'
+	fi
+	echo "Error: \${status}" >&2
+	exit 1
 fi
+EOF
+		echo 'installed' >> "${__messages_out}"
+		;;
 
-state_is="$(cat "$__object/explorer/pkg_state")"
-[ "$state_is" = "$state_should" ] && exit 0
+	absent)
+		# Use this because pkg_delete doesn't properly handle errors
+		cat << EOF
+status=\$(pkg_delete ${pkgopts} '${pkgid}' || true)
 
-case "$state_should" in
-    present)
-        # use this because pkg_add doesn't properly handle errors
-        cat << eof
-if [ X != X"${pkg_path}" ]; then
-    PKG_PATH="${pkg_path}"; export PKG_PATH
+if pkg_info -q -I 'inst:${pkgid}' | grep -q '^${name}-${version}.*${flavor}' 2>/dev/null
+then
+	# We found the package in the list of 'installed packages'.
+	# This would indicate that pkg_delete failed, send the output of pkg_delete
+
+	if [ -z "\${status}" ]; then
+		status='Failed to remove package, uncaught exception.'
+	fi
+	echo "Error: \${status}" >&2
+	exit 1
 fi
-status=\$(pkg_add "$pkgopts" "$pkgid" 2>&1)
-pkg_info -q -I "inst:$pkgid" | grep -q "^${name}-${version}.*${flavor}$" 2>/dev/null
-
-# We didn't find the package in the list of 'installed packages', so it failed
-# This is necessary because pkg_add doesn't return properly
-if [ \$? -ne 0 ]; then
-    if [ -z "\${status}" ]; then
-      status="Failed to add package, uncaught exception."
-    fi
-    echo "Error: \$status" >&2
-    exit 1
-fi
-echo "installed" >> "$__messages_out"
-eof
-    ;;
-
-    absent)
-        # use this because pkg_delete doesn't properly handle errors
-        cat << eof
-status=\$(pkg_delete "$pkgopts" "$pkgid")
-pkg_info -q -I "inst:$pkgid" | grep -q "^${name}-${version}.*${flavor}" 2>/dev/null
-
-# We found the package in the list of 'installed packages'
-# This would indicate that pkg_delete failed, send the output of pkg_delete
-if [ \$? -eq 0 ]; then
-    if [ -z "\${status}" ]; then
-      status="Failed to remove package, uncaught exception."
-    fi
-    echo "Error: \$status" >&2
-    exit 1
-fi
-echo "removed" >> "$__messages_out"
-eof
-   ;;
-   *)
-		echo "Unknown state: $state_should" >&2
+EOF
+		echo 'removed' >> "${__messages_out}"
+		;;
+	*)
+		echo "Unknown state: ${state_should}" >&2
 		exit 1
-   ;;
+		;;
 esac

--- a/cdist/conf/type/__package_pkgng_freebsd/gencode-remote
+++ b/cdist/conf/type/__package_pkgng_freebsd/gencode-remote
@@ -57,12 +57,15 @@ execcmd(){
    case "$1" in
       add)
          _cmd="${add_cmd} $2"
+         echo "installed" >> "$__messages_out"
          ;;
       rm)
          _cmd="${rm_cmd} $2"
+         echo "removed" >> "$__messages_out"
          ;;
       upg)
          _cmd="${upg_cmd} $2"
+         echo "installed" >> "$__messages_out"
          ;;
       *)
          printf "Error. Don't understand command: %s" "$1" >&2

--- a/cdist/conf/type/__package_rubygem/gencode-remote
+++ b/cdist/conf/type/__package_rubygem/gencode-remote
@@ -40,9 +40,11 @@ fi
 case "$state_should" in
     present)
         echo "gem install '$name' --no-ri --no-rdoc"
+        echo "installed" >> "$__messages_out"
     ;;
     absent)
         echo "gem uninstall '$name'"
+        echo "removed" >> "$__messages_out"
     ;;
     *)
         echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_yum/gencode-remote
+++ b/cdist/conf/type/__package_yum/gencode-remote
@@ -61,9 +61,11 @@ fi
 case "$state_should" in
     present)
         echo "yum $opts install '$install_name'"
+        echo "installed" >> "$__messages_out"
     ;;
     absent)
         echo "yum $opts remove '$name'"
+        echo "removed" >> "$__messages_out"
     ;;
     *)
         echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_zypper/gencode-remote
+++ b/cdist/conf/type/__package_zypper/gencode-remote
@@ -62,14 +62,17 @@ case "$state_should" in
         if [ -z "$version_should" ]; then
             [ "$state_is" = "present" ] && exit 0 # if state is present, we dont need to do anything
             echo "zypper $globalopts install --type '$ptype' --auto-agree-with-licenses '$name' >/dev/null"
+            echo "removed" >> "$__messages_out"
         else
             [ "$state_is" = "present" ] && [ "$version_should" = "$version_is" ] && exit 0 # if state is present and version is correct, we dont need to do anything
             echo "zypper $globalopts install --oldpackage --type '$ptype' --auto-agree-with-licenses '$name' = '$version_should' >/dev/null"
+            echo "installed" >> "$__messages_out"
         fi
     ;;
     absent)
         [ "$state_is" = "absent" ] && exit 0 # if state is absent, we dont need to do anything
         echo "zypper $globalopts remove --type '$ptype' '$name' >/dev/null"
+        echo "removed" >> "$__messages_out"
     ;;
     *)
         echo "Unknown state: $state_should" >&2


### PR DESCRIPTION
I extended all package types to post an "installed" message when a package has been installed (or updated) and a "removed" message when a package has been removed.

Also, I completely reworked the `__package_pkg_openbsd` type.