### PR TITLE
All package types send messages upon installation/removal

### DIFF
--- a/cdist/conf/type/__package_emerge/gencode-remote
+++ b/cdist/conf/type/__package_emerge/gencode-remote
@@ -64,9 +64,11 @@ fi
 case "$state_should" in
    present)
         echo "emerge '$name' &>/dev/null || exit 1"
+        echo "installed" >> "$__messages_out"
         ;;
    absent)
         echo "emerge -C '$name' &>/dev/null || exit 1"
+        echo "removed" >> "$__messages_out"
         ;;
    *)
         echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_emerge/gencode-remote
+++ b/cdist/conf/type/__package_emerge/gencode-remote
@@ -39,12 +39,12 @@ pkg_version="$(cat "$__object/explorer/pkg_version")"
 if [ -z "$pkg_version" ]; then
     state_is="absent"
 elif [ -z "$version" ] && [ "$(echo "$pkg_version" | wc -l)" -gt 1 ]; then
-    echo "Package name is not unique! The following packages are installed:"
-    echo "$pkg_version"
+    echo "Package name is not unique! The following packages are installed:" >&2
+    echo "$pkg_version" >&2
     exit 1
 elif [ -n "$version" ] && [ "$(echo "$pkg_version" | cut -d " " -f 1 | sort | uniq | wc -l)" -gt 1 ]; then
-    echo "Package name is not unique! The following packages are installed:"
-    echo "$pkg_version"
+    echo "Package name is not unique! The following packages are installed:" >&2
+    echo "$pkg_version" >&2
     exit 1
 else
     state_is="present"

--- a/cdist/conf/type/__package_emerge_dependencies/gencode-remote
+++ b/cdist/conf/type/__package_emerge_dependencies/gencode-remote
@@ -6,10 +6,11 @@ flaggie_installed="$(cat "$__object/explorer/flaggie_installed")"
 if [ "${gentoolkit_installed}" != "true" ]; then
     # emerge app-portage/gentoolkit
     echo "emerge app-portage/gentoolkit &> /dev/null || exit 1"
+    echo "installed app-portage/gentoolkit" >> "$__messages_out"
 fi
 
 if [ "${flaggie_installed}" != "true" ]; then
     # emerge app-portage/flaggie
     echo "emerge app-portage/flaggie &> /dev/null || exit 1"
+    echo "installed app-portage/flaggie" >> "$__messages_out"
 fi
-

--- a/cdist/conf/type/__package_luarocks/gencode-remote
+++ b/cdist/conf/type/__package_luarocks/gencode-remote
@@ -43,9 +43,11 @@ fi
 case "$state_should" in
     present)
         echo "luarocks install '$name'"
+        echo "installed" >> "$__messages_out"
     ;;
     absent)
         echo "luarocks remove '$name'"
+        echo "removed" >> "$__messages_out"
     ;;
     *)
         echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_opkg/gencode-remote
+++ b/cdist/conf/type/__package_opkg/gencode-remote
@@ -43,12 +43,14 @@ esac
 case "$state_should" in
     present)
         if [ "$present" = "notpresent" ]; then
-            echo opkg --verbosity=0 update
+            echo "opkg --verbosity=0 update"
         fi
         echo "opkg --verbosity=0 install '$name'"
+        echo "installed" >> "$__messages_out"
     ;;
     absent)
         echo "opkg --verbosity=0 remove '$name'"
+        echo "removed" >> "$__messages_out"
     ;;
     *)
         echo "Unknown state: ${state_should}" >&2

--- a/cdist/conf/type/__package_pacman/gencode-remote
+++ b/cdist/conf/type/__package_pacman/gencode-remote
@@ -46,9 +46,11 @@ fi
 case "$state_should" in
    present)
          echo "pacman --needed --noconfirm --noprogressbar -S '$name'"
+         echo "installed" >> "$__messages_out"
    ;;
    absent)
          echo "pacman --noconfirm --noprogressbar -R '$name'"
+         echo "removed" >> "$__messages_out"
    ;;
    *)
       echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_pip/gencode-remote
+++ b/cdist/conf/type/__package_pip/gencode-remote
@@ -57,6 +57,7 @@ case "$state_should" in
         else
             echo $pip install -q "$name"
         fi
+        echo "installed" >> "$__messages_out"
     ;;
     absent)
         if [ "$runas" ]
@@ -65,6 +66,7 @@ case "$state_should" in
         else
             echo $pip uninstall -q -y "$name"
         fi
+        echo "removed" >> "$__messages_out"
     ;;
     *)
         echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_pkg_freebsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_freebsd/gencode-remote
@@ -39,7 +39,7 @@ assert ()                 #  If condition false,
 		# shellcheck disable=SC2039
 		echo "File \"$0\", line $lineno, called by $(caller 0)"
 		exit $E_ASSERT_FAILED
-	fi  
+	fi
 }
 
 # Debug
@@ -89,6 +89,7 @@ if [ -n "$curr_version" ]; then	# PKG *is* installed
 			cmd="${rm_cmd} ${name}-${curr_version}"
 		fi
 		execcmd "remove" "${cmd}"
+		echo "removed" >> "$__messages_out"
 		exit 0
 	else	# Should be installed
 		if [ -n "$version" ]; then	# Want a specific version
@@ -102,6 +103,7 @@ if [ -n "$curr_version" ]; then	# PKG *is* installed
 				execcmd "remove" "${cmd}"
 				cmd="${add_cmd} -r ${name}-${version}"
 				execcmd "add" "${cmd}"
+				echo "installed" >> "$__messages_out"
 			fi
 		else	# Don't care what version to use
 			exit 0
@@ -120,6 +122,7 @@ else	# PKG *isn't* installed
 			cmd="${cmd}-${version}"
 		fi
 		execcmd "add" "${cmd}"
+		echo "installed" >> "$__messages_out"
 		exit 0
 	fi
 fi

--- a/cdist/conf/type/__package_pkg_openbsd/gencode-remote
+++ b/cdist/conf/type/__package_pkg_openbsd/gencode-remote
@@ -62,15 +62,15 @@ state_should="$(cat "$__object/parameter/state")"
 
 pkg_version="$(cat "$__object/explorer/pkg_version")"
 
-if [ -f "$__object/parameter/pkg_path" ]; then                                  
-  pkg_path="$(cat "$__object/parameter/pkg_path")"                              
+if [ -f "$__object/parameter/pkg_path" ]; then
+  pkg_path="$(cat "$__object/parameter/pkg_path")"
 else
   has_installurl=$(cat "${__object}/explorer/has_installurl")
   if [ Xyes != X"${has_installurl}" ]; then
       # there is no default PKG_PATH, try to provide one
       pkg_path="ftp://ftp.openbsd.org/pub/OpenBSD/$os_version/packages/$machine/"
   fi
-fi                                                                              
+fi
 
 if [ "$pkg_version" ]; then
     state_is="present"
@@ -99,11 +99,12 @@ if [ \$? -ne 0 ]; then
     echo "Error: \$status"
     exit 1
 fi
+echo "installed" >> "$__messages_out"
 eof
     ;;
 
     absent)
-        # use this because pkg_add doesn't properly handle errors
+        # use this because pkg_delete doesn't properly handle errors
         cat << eof
 status=\$(pkg_delete "$pkgopts" "$pkgid")
 pkg_info | grep "^${name}.*${version}.*${flavor}" > /dev/null 2>&1
@@ -117,6 +118,7 @@ if [ \$? -eq 0 ]; then
     echo "Error: \$status"
     exit 1
 fi
+echo "removed" >> "$__messages_out"
 eof
    ;;
    *)

--- a/cdist/conf/type/__package_pkgng_freebsd/gencode-remote
+++ b/cdist/conf/type/__package_pkgng_freebsd/gencode-remote
@@ -57,12 +57,15 @@ execcmd(){
    case "$1" in
       add)
          _cmd="${add_cmd} $2"
+         echo "installed" >> "$__messages_out"
          ;;
       rm)
          _cmd="${rm_cmd} $2"
+         echo "removed" >> "$__messages_out"
          ;;
       upg)
          _cmd="${upg_cmd} $2"
+         echo "installed" >> "$__messages_out"
          ;;
       *)
          printf "Error. Don't understand command: %s" "$1" >&2

--- a/cdist/conf/type/__package_rubygem/gencode-remote
+++ b/cdist/conf/type/__package_rubygem/gencode-remote
@@ -40,9 +40,11 @@ fi
 case "$state_should" in
     present)
         echo "gem install '$name' --no-ri --no-rdoc"
+        echo "installed" >> "$__messages_out"
     ;;
     absent)
         echo "gem uninstall '$name'"
+        echo "removed" >> "$__messages_out"
     ;;
     *)
         echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_yum/gencode-remote
+++ b/cdist/conf/type/__package_yum/gencode-remote
@@ -61,9 +61,11 @@ fi
 case "$state_should" in
     present)
         echo "yum $opts install '$install_name'"
+        echo "installed" >> "$__messages_out"
     ;;
     absent)
         echo "yum $opts remove '$name'"
+        echo "removed" >> "$__messages_out"
     ;;
     *)
         echo "Unknown state: $state_should" >&2

--- a/cdist/conf/type/__package_zypper/gencode-remote
+++ b/cdist/conf/type/__package_zypper/gencode-remote
@@ -62,14 +62,17 @@ case "$state_should" in
         if [ -z "$version_should" ]; then
             [ "$state_is" = "present" ] && exit 0 # if state is present, we dont need to do anything
             echo "zypper $globalopts install --type '$ptype' --auto-agree-with-licenses '$name' >/dev/null"
+            echo "removed" >> "$__messages_out"
         else
             [ "$state_is" = "present" ] && [ "$version_should" = "$version_is" ] && exit 0 # if state is present and version is correct, we dont need to do anything
             echo "zypper $globalopts install --oldpackage --type '$ptype' --auto-agree-with-licenses '$name' = '$version_should' >/dev/null"
+            echo "installed" >> "$__messages_out"
         fi
     ;;
     absent)
         [ "$state_is" = "absent" ] && exit 0 # if state is absent, we dont need to do anything
         echo "zypper $globalopts remove --type '$ptype' '$name' >/dev/null"
+        echo "removed" >> "$__messages_out"
     ;;
     *)
         echo "Unknown state: $state_should" >&2


### PR DESCRIPTION
I extended all package types to post an "installed" message when a package has been installed (or upgraded) and a "removed" message when a package has been removed.