### PR TITLE
readd the use of echo in my explorers

### DIFF
--- a/cdist/conf/type/__zypper_repo/explorer/all_repo_ids
+++ b/cdist/conf/type/__zypper_repo/explorer/all_repo_ids
@@ -21,4 +21,4 @@
 # Retrieve all repo id nummbers - parsed zypper output
 #
 #
-zypper lr | cut -d'|' -f 1 | grep -E '^[0-9]'
+echo $(zypper lr | cut -d'|' -f 1 | grep -E '^[0-9]')

--- a/cdist/conf/type/__zypper_repo/explorer/all_repo_ids
+++ b/cdist/conf/type/__zypper_repo/explorer/all_repo_ids
@@ -21,4 +21,5 @@
 # Retrieve all repo id nummbers - parsed zypper output
 #
 #
+# shellcheck disable=SC2005
 echo $(zypper lr | cut -d'|' -f 1 | grep -E '^[0-9]')

--- a/cdist/conf/type/__zypper_repo/explorer/enabled_repo_ids
+++ b/cdist/conf/type/__zypper_repo/explorer/enabled_repo_ids
@@ -23,4 +23,4 @@
 #
 # simpler command which works only on SLES11 SP3 or newer:
 # echo $(zypper lr -E | cut -d'|' -f 1 | grep -E '^[0-9]')
-zypper lr |  grep -E '^[0-9]([^|]+\|){3,3} Yes' | cut -d'|' -f 1
+echo $(zypper lr |  grep -E '^[0-9]([^|]+\|){3,3} Yes' | cut -d'|' -f 1)

--- a/cdist/conf/type/__zypper_repo/explorer/enabled_repo_ids
+++ b/cdist/conf/type/__zypper_repo/explorer/enabled_repo_ids
@@ -23,4 +23,6 @@
 #
 # simpler command which works only on SLES11 SP3 or newer:
 # echo $(zypper lr -E | cut -d'|' -f 1 | grep -E '^[0-9]')
+#
+# shellcheck disable=SC2005
 echo $(zypper lr |  grep -E '^[0-9]([^|]+\|){3,3} Yes' | cut -d'|' -f 1)

--- a/cdist/conf/type/__zypper_repo/explorer/repo_id
+++ b/cdist/conf/type/__zypper_repo/explorer/repo_id
@@ -26,4 +26,5 @@ if [ -f "$__object/parameter/uri" ]; then
 else
    uri="$__object_id"
 fi
+# shellcheck disable=SC2005
 echo $(zypper lr -u | grep -F "$uri" | cut -d'|' -f 1 | grep -E '^[0-9]')

--- a/cdist/conf/type/__zypper_repo/explorer/repo_id
+++ b/cdist/conf/type/__zypper_repo/explorer/repo_id
@@ -26,4 +26,4 @@ if [ -f "$__object/parameter/uri" ]; then
 else
    uri="$__object_id"
 fi
-zypper lr -u | grep -F "$uri" | cut -d'|' -f 1 | grep -E '^[0-9]'
+echo $(zypper lr -u | grep -F "$uri" | cut -d'|' -f 1 | grep -E '^[0-9]')

--- a/cdist/conf/type/__zypper_service/explorer/repo_ids
+++ b/cdist/conf/type/__zypper_service/explorer/repo_ids
@@ -24,4 +24,6 @@
 # simpler command which works only on SLES11 SP3 or newer:
 # echo $(zypper lr -u -E | cut -d'|' -f 1 | grep -E '^[0-9]')
 # on older systems, zypper doesn't know the parameter -E 
+#
+# shellcheck disable=SC2005
 echo $(zypper lr -u | grep -E '^([^|]+\|){3,3} Yes' | cut -d'|' -f 1 | grep -E '^[0-9]')

--- a/cdist/conf/type/__zypper_service/explorer/repo_ids
+++ b/cdist/conf/type/__zypper_service/explorer/repo_ids
@@ -24,4 +24,4 @@
 # simpler command which works only on SLES11 SP3 or newer:
 # echo $(zypper lr -u -E | cut -d'|' -f 1 | grep -E '^[0-9]')
 # on older systems, zypper doesn't know the parameter -E 
-zypper lr -u | grep -E '^([^|]+\|){3,3} Yes' | cut -d'|' -f 1 | grep -E '^[0-9]'
+echo $(zypper lr -u | grep -E '^([^|]+\|){3,3} Yes' | cut -d'|' -f 1 | grep -E '^[0-9]')

--- a/cdist/conf/type/__zypper_service/explorer/service_id
+++ b/cdist/conf/type/__zypper_service/explorer/service_id
@@ -27,4 +27,6 @@ else
 fi
 # simpler command which works only on SLES11 SP3 or newer:
 # echo $(zypper ls -u -E | grep -E "\<$uri\>" | cut -d'|' -f 1 )
+#
+# shellcheck disable=SC2005
 echo $(zypper ls -u | grep -E '^([^|]+\|){3,3} Yes' | grep -E "\\<$uri\\>" | cut -d'|' -f 1)

--- a/cdist/conf/type/__zypper_service/explorer/service_id
+++ b/cdist/conf/type/__zypper_service/explorer/service_id
@@ -27,4 +27,4 @@ else
 fi
 # simpler command which works only on SLES11 SP3 or newer:
 # echo $(zypper ls -u -E | grep -E "\<$uri\>" | cut -d'|' -f 1 )
-zypper ls -u | grep -E '^([^|]+\|){3,3} Yes' | grep -E "\\<$uri\\>" | cut -d'|' -f 1
+echo $(zypper ls -u | grep -E '^([^|]+\|){3,3} Yes' | grep -E "\\<$uri\\>" | cut -d'|' -f 1)

--- a/cdist/conf/type/__zypper_service/explorer/service_ids
+++ b/cdist/conf/type/__zypper_service/explorer/service_ids
@@ -22,4 +22,6 @@
 #
 # simpler command which works only on SLES11 SP3 or newer:
 # echo $(zypper ls -u -E | cut -d'|' -f 1 | grep -E '^[0-9]')
+#
+# shellcheck disable=SC2005
 echo $(zypper ls -u | grep -E '^([^|]+\|){3,3} Yes' | cut -d'|' -f 1 | grep -E '^[0-9]')

--- a/cdist/conf/type/__zypper_service/explorer/service_ids
+++ b/cdist/conf/type/__zypper_service/explorer/service_ids
@@ -22,4 +22,4 @@
 #
 # simpler command which works only on SLES11 SP3 or newer:
 # echo $(zypper ls -u -E | cut -d'|' -f 1 | grep -E '^[0-9]')
-zypper ls -u | grep -E '^([^|]+\|){3,3} Yes' | cut -d'|' -f 1 | grep -E '^[0-9]'
+echo $(zypper ls -u | grep -E '^([^|]+\|){3,3} Yes' | cut -d'|' -f 1 | grep -E '^[0-9]')

--- a/cdist/conf/type/__zypper_service/explorer/service_uri
+++ b/cdist/conf/type/__zypper_service/explorer/service_uri
@@ -25,4 +25,5 @@ if [ -f "$__object/parameter/uri" ]; then
 else
    uri="/$__object_id"
 fi
+# shellcheck disable=SC2005
 echo $(zypper ls -u | awk 'BEGIN { FS = "[ ]+\\|[ ]+" } ; $4 == "Yes" && $NF == "'"$uri"'" {print $NF}')

--- a/cdist/conf/type/__zypper_service/explorer/service_uri
+++ b/cdist/conf/type/__zypper_service/explorer/service_uri
@@ -25,4 +25,4 @@ if [ -f "$__object/parameter/uri" ]; then
 else
    uri="/$__object_id"
 fi
-zypper ls -u | awk 'BEGIN { FS = "[ ]+\\|[ ]+" } ; $4 == "Yes" && $NF == "'"$uri"'" {print $NF}'
+echo $(zypper ls -u | awk 'BEGIN { FS = "[ ]+\\|[ ]+" } ; $4 == "Yes" && $NF == "'"$uri"'" {print $NF}')


### PR DESCRIPTION
this is nessessary for
 remove blanks in output (strip)
 catch exit codes of zypper (for example if no repo is defined at all)

==> without this echo's the type's doesn't work at all.