### PR TITLE
Added a startup flag for prometheus alertmanager

### DIFF
--- a/cdist/conf/type/__prometheus_alertmanager/manifest
+++ b/cdist/conf/type/__prometheus_alertmanager/manifest
@@ -49,7 +49,7 @@ __key_value alertmanager_fix_init_script --file /etc/init.d/prometheus-alertmana
 
 ##### CONFIGURE #############################################################
 
-FLAGS="--storage.path $storage_path --data.retention $((retention_days*24))h --web.listen-address [::]:9093"
+FLAGS="--storage.path $storage_path --data.retention $((retention_days*24))h --web.listen-address [::]:9093 --cluster.advertise-address [::]:9093"
 
 require="$require $require_pkg" \
 __key_value alertmanager_args --file /etc/default/prometheus-alertmanager \


### PR DESCRIPTION
aded the flag --cluster.advertise-address since it is needed for startup on a machine
which does not provide a private v4