### PR TITLE
Use portable -p instead of --tmpdir for mktemp

### DIFF
--- a/cdist/conf/type/__staged_file/gencode-local
+++ b/cdist/conf/type/__staged_file/gencode-local
@@ -63,7 +63,7 @@ fetch_file() {
 
 fetch_and_prepare_file() {
    # shellcheck disable=SC2016
-   printf 'tmpdir="$(mktemp -d --tmpdir="/tmp" "%s")"\n' "${__type##*/}.XXXXXXXXXX"
+   printf 'tmpdir="$(mktemp -d -p "/tmp" "%s")"\n' "${__type##*/}.XXXXXXXXXX"
    # shellcheck disable=SC2016
    printf 'cd "$tmpdir"\n'
    # shellcheck disable=SC2059


### PR DESCRIPTION
-p is equivalent to --tmpdir, but more portable, since it works across
GNU/Linux and *BSDs