### PR TITLE
new type: __clean_path

### DIFF
--- a/cdist/conf/type/__clean_path/explorer/list
+++ b/cdist/conf/type/__clean_path/explorer/list
@@ -1,0 +1,39 @@
+#!/bin/sh -e
+#
+# 2019 Ander Punnar (ander-at-kvlt-dot-ee)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+
+path="/$__object_id"
+
+if [ ! -d "$path" ]
+then
+    echo "$path is not a directory" >&2
+    exit 1
+fi
+
+pattern="$( cat "$__object/parameter/pattern" )"
+
+if [ -f "$__object/parameter/exclude" ]
+then
+    exclude="$( cat "$__object/parameter/exclude" )"
+
+    find "$path" -mindepth 1 -maxdepth 1 -regex "$pattern" \
+        -and -not -regex "$exclude"
+else
+    find "$path" -mindepth 1 -maxdepth 1 -regex "$pattern"
+fi

--- a/cdist/conf/type/__clean_path/gencode-remote
+++ b/cdist/conf/type/__clean_path/gencode-remote
@@ -1,0 +1,48 @@
+#!/bin/sh -e
+#
+# 2019 Ander Punnar (ander-at-kvlt-dot-ee)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+
+[ ! -s "$__object/explorer/list" ] && exit 0
+
+path="/$__object_id"
+
+pattern="$( cat "$__object/parameter/pattern" )"
+
+if [ -f "$__object/parameter/exclude" ]
+then
+    exclude="$( cat "$__object/parameter/exclude" )"
+
+    echo "find '$path' -mindepth 1 -maxdepth 1 -regex '$pattern'" \
+        "-and -not -regex '$exclude'" \
+        '-exec rm -rf {} \;'
+else
+    echo "find '$path' -mindepth 1 -maxdepth 1 -regex '$pattern'" \
+        '-exec rm -rf {} \;'
+fi
+
+while read -r f
+do
+    echo "removed '$f'" >> "$__messages_out"
+done \
+< "$__object/explorer/list"
+
+if [ -f "$__object/parameter/onchange" ]
+then
+    cat "$__object/parameter/onchange"
+fi

--- a/cdist/conf/type/__clean_path/man.rst
+++ b/cdist/conf/type/__clean_path/man.rst
@@ -1,0 +1,60 @@
+cdist-type__clean_path(7)
+=========================
+
+NAME
+----
+cdist-type__clean_path - Remove files and directories which match the pattern.
+
+
+DESCRIPTION
+-----------
+Remove files and directories which match the pattern.
+
+Provided path (as __object_id) must be a directory.
+
+Patterns are passed to ``find``'s ``-regex`` - see ``find(1)`` for more details.
+
+Look up of files and directories is non-recursive (``-maxdepth 1``).
+
+Parent directory is excluded (``-mindepth 1``).
+
+This type is not POSIX compatible (sorry, Solaris users).
+
+
+REQUIRED PARAMETERS
+-------------------
+pattern
+   Pattern of files which are removed from path.
+
+
+OPTIONAL PARAMETERS
+-------------------
+exclude
+   Pattern of files which are excluded from removal.
+
+onchange
+   The code to run if files or directories were removed.
+
+
+EXAMPLES
+--------
+
+.. code-block:: sh
+
+    __clean_path /etc/apache2/conf-enabled \
+        --pattern '.+' \
+        --exclude '.+\(charset\.conf\|security\.conf\)' \
+        --onchange 'service apache2 restart'
+
+
+AUTHORS
+-------
+Ander Punnar <ander-at-kvlt-dot-ee>
+
+
+COPYING
+-------
+Copyright \(C) 2019 Ander Punnar. You can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.

--- a/cdist/conf/type/__clean_path/parameter/optional
+++ b/cdist/conf/type/__clean_path/parameter/optional
@@ -1,0 +1,2 @@
+exclude
+onchange

--- a/cdist/conf/type/__clean_path/parameter/required
+++ b/cdist/conf/type/__clean_path/parameter/required
@@ -1,0 +1,1 @@
+pattern


### PR DESCRIPTION
too often i need to make sure that some directories are empty or directory only contains files i know it should contain.

one good example is apache2 packaging and `conf-enabled`, `mods-enabled` and `sites-enabled` directories.

hopefully this somewhat dangerous type is useful to other people.