### PR TITLE
UFW (Uncomplicated FireWall)

### DIFF
--- a/cdist/conf/type/__ufw/gencode-remote
+++ b/cdist/conf/type/__ufw/gencode-remote
@@ -1,0 +1,62 @@
+#!/bin/sh -e
+#
+# 2019 Mark Polyakov (mark--@--markasoftware.com)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+
+state="$(cat "$__object/parameter/state")"
+
+case "$state" in
+    enabled)
+        echo 'ufw --force enable'
+        ;;
+
+    present)
+        echo 'ufw --force disable'
+        ;;
+    # absent will be uninstalled in manifest
+esac
+
+if [ "$state" != absent ]; then
+    if [ -f "$__object/parameter/logging" ]; then
+        logging="$(cat "$__object/parameter/logging")"
+        case "$logging" in
+            off|low|medium|high|full)
+                echo "ufw --force logging $logging"
+                ;;
+            *)
+                echo 'Logging parameter must be off, low, medium, high, or full!' >&2
+                exit 1
+                ;;
+        esac
+    fi
+
+    for direction in incoming outgoing routed; do
+        if [ -f "$__object/parameter/default_$direction" ]; then
+            treatment="$(cat "$__object/parameter/default_$direction")"
+            case "$treatment" in
+                allow|deny|reject)
+                    echo "ufw --force default $treatment $direction"
+                    ;;
+                *)
+                    echo 'UFW default policies must be either "allow", "deny", or "reject".' >&2
+                    exit 1
+                    ;;
+            esac
+        fi
+    done
+fi

--- a/cdist/conf/type/__ufw/man.rst
+++ b/cdist/conf/type/__ufw/man.rst
@@ -1,0 +1,59 @@
+cdist-type__ufw(7)
+==================
+
+NAME
+----
+cdist-type__ufw - Install the Uncomplicated FireWall
+
+
+DESCRIPTION
+-----------
+Installs the Uncomplicated FireWall. Most modern distributions carry UFW in their main repositories, but on CentOS this type will automatically enable the EPEL repository.
+
+Some global configuration can also be set with this type.
+
+OPTIONAL PARAMETERS
+-------------------
+state
+    Either "enabled", "running", "present", or "absent". Defaults to "enabled", which registers UFW to start on boot.
+
+logging
+    Either "off", "low", "medium", "high", or "full". Will be passed to `ufw logging`. If not specified, logging level is not modified.
+
+default_incoming
+    Either "allow", "deny", or "reject". The default policy for dealing with ingress packets.
+    
+default_outgoing
+    Either "allow", "deny", or "reject". The default policy for dealing with egress packets.
+    
+default_routed
+    Either "allow", "deny", or "reject". The default policy for dealing with routed packets (passing through this machine).
+    
+
+EXAMPLES
+--------
+
+.. code-block:: sh
+
+    # Install UFW
+    __ufw
+    # Setup UFW with maximum logging and no restrictions on routed packets.
+    __ufw --logging full --default_routed allow
+
+
+SEE ALSO
+--------
+:strong:`ufw`\ (8)
+
+
+AUTHORS
+-------
+Mark Polyakov <mark@markasoftware.com>
+
+
+COPYING
+-------
+Copyright \(C) 2019 Mark Polyakov. You can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.

--- a/cdist/conf/type/__ufw/manifest
+++ b/cdist/conf/type/__ufw/manifest
@@ -1,0 +1,67 @@
+#!/bin/sh -e
+#
+# 2019 Mark Polyakov (mark--@--markasoftware.com)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+
+state="$(cat "$__object/parameter/state")"
+
+case "$state" in
+    present|enabled)
+        os="$(cat "$__global/explorer/os")"
+
+        case "$os" in
+            centos)
+                # shellcheck source=/dev/null
+                if (. "$__global/explorer/os_release" && [ "${VERSION_ID}" = "7" ]); then
+                    __package epel-release
+                    require='__package/epel-release' __package ufw
+                else
+                    echo 'CentOS version 7 is required!'
+                    exit 1
+                fi
+                ;;
+            *)
+                __package ufw
+                ;;
+        esac
+
+        # ufw expects to always be enabled, then uses a switch in /etc to
+        # determine whether to "actually start" after the init system calls it.
+        # So, we have to both enable on bootup through init and run `ufw enable`
+
+        # operators ae left-associative, so if !enabled it will never run
+        if [ "$(cat "$__global/explorer/os")" != ubuntu ] || \
+           [ "$(cat "$__global/explorer/init")" != init ] && \
+           [ "$state" = enabled ]; then
+            # Why don't we disable start_on_boot when state=present|absent?
+            # Because UFW should always be enabled at boot -- /etc/ufw/ufw.conf
+            # will stop it from "really" starting
+            require='__package/ufw' __start_on_boot ufw
+        fi
+        ;;
+
+    absent)
+        __package ufw --state absent
+        ;;
+
+    *)
+        echo 'State must be "enabled", "present", or "absent".'
+        exit 1
+        ;;
+esac
+

--- a/cdist/conf/type/__ufw/parameter/default/state
+++ b/cdist/conf/type/__ufw/parameter/default/state
@@ -1,0 +1,1 @@
+enabled

--- a/cdist/conf/type/__ufw/parameter/optional
+++ b/cdist/conf/type/__ufw/parameter/optional
@@ -1,0 +1,5 @@
+state
+logging
+default_incoming
+default_outgoing
+default_routed

--- a/cdist/conf/type/__ufw_rule/gencode-remote
+++ b/cdist/conf/type/__ufw_rule/gencode-remote
@@ -1,0 +1,45 @@
+#!/bin/sh -e
+#
+# 2019 Mark Polyakov (mark@markasoftware.com)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This type does not bother with checking the current state of the rules.
+# While it is possible to retrieve the list of rules in a consistent format from
+# `ufw status`, it is a completely different format than the one used on the
+# command line. I also do not suspect it is any faster.
+
+ufw='ufw --force rule'
+
+case "$(cat "$__object/parameter/state")" in
+    present) ;;
+    absent)
+        ufw="$ufw delete"
+        ;;
+    *)
+        echo 'State must be "present" or "absent".' >&2
+        exit 1
+        ;;
+esac
+
+if [ -f "$__object/parameter/rule" ]; then
+    ufw="$ufw $(cat "$__object/parameter/rule")"
+else
+    ufw="$ufw allow $__object_id"
+fi
+
+echo "$ufw"

--- a/cdist/conf/type/__ufw_rule/man.rst
+++ b/cdist/conf/type/__ufw_rule/man.rst
@@ -1,0 +1,53 @@
+cdist-type__ufw_rule(7)
+=======================
+
+NAME
+----
+cdist-type__ufw_rule - A single UFW rule
+
+
+DESCRIPTION
+-----------
+Adds or removes a single UFW rule. This type supports adding and deleting rules for port ranges or applications.
+
+Understanding what is "to" and what is "from" can be confusing. If the rule is ingress (default), then "from" is the remote machine and "to" is the local one. The opposite is true for egress traffic (--out).
+
+OPTIONAL PARAMETERS
+-------------------
+state
+    Either "present" or "absent". Defaults to "present". If "absent", only removes rules that exactly match the rule expected.
+
+rule
+    A firewall rule in UFW syntax. This is what you would usually write after `ufw` on the command line. Defaults to "allow" followed by the object ID. You can use either the short syntax (just allow|deny|reject|limit followed by a port or application name) or the full syntax. Do not include `delete` in your command. Set `--state absent` instead.
+
+EXAMPLES
+--------
+
+.. code-block:: sh
+
+    # open port 80 (ufw allow 80)
+    __ufw_rule 80
+    # Allow mosh application (if installed)
+    __ufw_rule mosh
+    # Allow all traffic from local network (ufw allow from 10.0.0.0/24)
+    __ufw_rule local --rule 'allow from 10.0.0.0/24'
+    # Block egress traffic from port 25 to 111.55.55.55 on interface eth0
+    __ufw_rule block_smtp --rule 'deny out on eth0 from any port 25 to 111.55.55.55'
+
+
+SEE ALSO
+--------
+:strong:`ufw`\ (8)
+
+
+AUTHORS
+-------
+Mark Polyakov <mark@markasoftware.com>
+
+
+COPYING
+-------
+Copyright \(C) 2019 Mark Polyakov. You can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.

--- a/cdist/conf/type/__ufw_rule/parameter/default/state
+++ b/cdist/conf/type/__ufw_rule/parameter/default/state
@@ -1,0 +1,1 @@
+present

--- a/cdist/conf/type/__ufw_rule/parameter/optional
+++ b/cdist/conf/type/__ufw_rule/parameter/optional
@@ -1,0 +1,2 @@
+state
+rule


### PR DESCRIPTION
I have added the following types:

* `__ufw`: Install and optionally enable UFW
* `__ufw_rule`: Add a normal UFW rule, with all of the UFW command line options translated into cdist-friendly parameters.
* `__ufw_default`: Set default policies (very simple).

This is my first time contributing to cdist, so I have a question: Since UFW's command line is idempotent, my types do not bother using explorers to check whether their work needs to be done -- `gencode-remote` always outputs something. An explorer would have to call `ufw status verbose`, which is not substantially faster than just doing the work I want to do. Is this OK?

Thanks for reviewing this!