### PR TITLE
fix disks explorer

### DIFF
--- a/cdist/conf/explorer/disks
+++ b/cdist/conf/explorer/disks
@@ -11,7 +11,7 @@ case "$os" in
     ;;
     *)
         # hopefully everything else is linux
-        if which lsblk > /dev/null
+        if command -v lsblk > /dev/null
         then
             # exclude ram disks and cdroms 
             lsblk -e 1,11 -dno name | xargs

--- a/cdist/conf/explorer/disks
+++ b/cdist/conf/explorer/disks
@@ -13,7 +13,7 @@ case "$os" in
         # hopefully everything else is linux
         if command -v lsblk > /dev/null
         then
-            # exclude ram disks and cdroms 
+            # exclude ram disks, floppies and cdroms 
             lsblk -e 1,2,11 -dno name | xargs
         else
             # fallback

--- a/cdist/conf/explorer/disks
+++ b/cdist/conf/explorer/disks
@@ -14,7 +14,7 @@ case "$os" in
         if command -v lsblk > /dev/null
         then
             # exclude ram disks and cdroms 
-            lsblk -e 1,11 -dno name | xargs
+            lsblk -e 1,2,11 -dno name | xargs
         else
             # fallback
             find /dev \

--- a/cdist/conf/explorer/disks
+++ b/cdist/conf/explorer/disks
@@ -14,6 +14,7 @@ case "$os" in
         if command -v lsblk > /dev/null
         then
             # exclude ram disks, floppies and cdroms 
+            # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
             lsblk -e 1,2,11 -dno name | xargs
         else
             # fallback

--- a/cdist/conf/explorer/disks
+++ b/cdist/conf/explorer/disks
@@ -10,7 +10,7 @@ case "$os" in
         sysctl -n hw.disknames | grep -Eo '[sw]d[0-9]+' | xargs
     ;;
     netbsd)
-        sysctl -n hw.disknames | grep -Eo 'ld[0-9]' | xargs
+        sysctl -n hw.disknames | grep -Eo '[lsw]d[0-9]' | xargs
     ;;
     *)
         # hopefully everything else is linux

--- a/cdist/conf/explorer/disks
+++ b/cdist/conf/explorer/disks
@@ -1,16 +1,26 @@
 #!/bin/sh -e
 
-os=$("$__explorer/os")
-case "$os" in
-    openbsd)
-        IFS=',' disks=$(sysctl -n hw.disknames)
-        for d in $disks; do
-            echo "${d%%:*}"
-        done | sed -n '/^[sw]d[0-9][0-9]*/p'
-    ;;
+os="$( "$__explorer/os" )"
 
+case "$os" in
+    freebsd)
+        sysctl -n kern.disks
+    ;;
+    openbsd)
+        sysctl -n hw.disknames | grep -Eo '[sw]d[0-9]+' | xargs
+    ;;
     *)
-        cd /dev || exit 0
-        echo sd? hd? vd?
+        # hopefully everything else is linux
+        if which lsblk > /dev/null
+        then
+            # exclude ram disks and cdroms 
+            lsblk -e 1,11 -dno name | xargs
+        else
+            # fallback
+            find /dev \
+                -type b \
+                -regex '/dev/\(hd\|sd\|vd\)[a-z]+' \
+                -printf '%f '
+        fi
     ;;
 esac

--- a/cdist/conf/explorer/disks
+++ b/cdist/conf/explorer/disks
@@ -9,6 +9,9 @@ case "$os" in
     openbsd)
         sysctl -n hw.disknames | grep -Eo '[sw]d[0-9]+' | xargs
     ;;
+    netbsd)
+        sysctl -n hw.disknames | grep -Eo 'ld[0-9]' | xargs
+    ;;
     *)
         # hopefully everything else is linux
         if command -v lsblk > /dev/null


### PR DESCRIPTION
```
$ cdist-dump -E test | grep disks
./explorer/disks:sda sdb sdc sdd sde hd? vd?
```
bug, because `hd?` and `vd?` are not expanded.