### PR TITLE
explorer/disks: do fallback right, in a POSIX way

### DIFF
--- a/cdist/conf/explorer/disks
+++ b/cdist/conf/explorer/disks
@@ -1,27 +1,27 @@
 #!/bin/sh -e
 
-os="$( "$__explorer/os" )"
+uname_s="$(uname -s)"
 
-case "$os" in
-    freebsd)
+case "${uname_s}" in
+    FreeBSD)
         sysctl -n kern.disks
     ;;
-    openbsd)
-        sysctl -n hw.disknames | grep -Eo '[sw]d[0-9]+' | xargs
+    OpenBSD|NetBSD)
+        sysctl -n hw.disknames | grep -Eo '[lsw]d[0-9]+' | xargs
     ;;
-    netbsd)
-        sysctl -n hw.disknames | grep -Eo '[lsw]d[0-9]' | xargs
-    ;;
-    *)
-        # hopefully everything else is linux
+    Linux)
         if command -v lsblk > /dev/null
         then
             # exclude ram disks, floppies and cdroms
             # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
             lsblk -e 1,2,11 -dno name | xargs
         else
-            # fallback
-            cd /dev && echo [vsh]d?
+            printf "%s operating system without lsblk is not supported, if you can please submit a patch\n" "${uname_s}" >&2
+            exit 1
         fi
+    ;;
+    *)
+        printf "%s operating system is not supported, if you can please submit a patch\n" "${uname_s}" >&2
+        exit 1
     ;;
 esac


### PR DESCRIPTION
https://github.com/ungleich/cdist/commit/aba1ae68f073382d7f0488b98c69af3e46b8d26a is wrong!

I don't have hd, sd, nor vd and the result is:
```
$ cd /dev && echo [vsh]d?
[vsh]d?
```
And https://github.com/ungleich/cdist/commit/1c152f0acbf2f7531fd4c129b04a1658654aa05e does not work with `find` implementations without `-printf`.

So here I am trying to do it with tools that POSIX specifies.

@telmich Can you test this one with alpine linux?
@4nd3r Can you test this with your machines if you have some for fallback?