### PR TITLE
global interfaces explorer: only check if we have ip or ifconfig

### DIFF
--- a/cdist/conf/explorer/interfaces
+++ b/cdist/conf/explorer/interfaces
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/sh -e
 #
-# 2012 Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>
+# 2019 Ander Punnar (ander-at-kvlt-dot-ee)
 #
 # This file is part of cdist.
 #
@@ -17,35 +17,14 @@
 # You should have received a copy of the GNU General Public License
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
-#
-# List all network interfaces in explorer/ifaces. One interface per line.
-#
-# If your OS is not supported please provide a ifconfig output
-#
 
-# Use ip, if available
-if command -v ip >/dev/null; then
+if command -v ip > /dev/null
+then
     ip -o link show | sed -n 's/^[0-9]\+: \(.\+\): <.*/\1/p'
-    exit 0
+
+elif command -v ifconfig > /dev/null
+then
+    ifconfig -a \
+        | sed -n -E 's/^(.*)(:[[:space:]]*flags=|Link encap).*/\1/p' \
+        | sort -u
 fi
-
-if ! command -v ifconfig >/dev/null; then
-   # no ifconfig, nothing we could do
-   exit 0
-fi
-
-uname_s="$(uname -s)"
-REGEXP='s/^(.*)(:[[:space:]]*flags=|Link encap).*/\1/p'
-
-case "$uname_s" in
-    Darwin)
-	ifconfig -a | sed -n -E "$REGEXP"
-	;;
-    Linux|*BSD)
-	ifconfig -a | sed -n -r "$REGEXP"
-	;;
-    *)
-	echo "Unsupported ifconfig output for $uname_s" >&2
-	exit 1
-	;;
-esac


### PR DESCRIPTION
 and be more compatible.

tests on debian, centos, freebsd, openbsd, netbsd and solaris confirm that this is enough and extra os check is not needed here.