### PR TITLE
Print empty disk list for unsupported OS

### DIFF
--- a/cdist/conf/explorer/disks
+++ b/cdist/conf/explorer/disks
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 
 uname_s="$(uname -s)"
 
@@ -16,12 +16,12 @@ case "${uname_s}" in
             # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
             lsblk -e 1,2,11 -dno name | xargs
         else
-            printf "%s operating system without lsblk is not supported, if you can please submit a patch\n" "${uname_s}" >&2
-            exit 1
+            printf "Don't know how to list disks for %s operating system without lsblk, if you can please submit a patch\n" "${uname_s}" >&2
         fi
     ;;
     *)
-        printf "%s operating system is not supported, if you can please submit a patch\n" "${uname_s}" >&2
-        exit 1
+        printf "Don't know how to list disks for %s operating system, if you can please submit a patch\n" "${uname_s}" >&2
     ;;
 esac
+
+exit 0


### PR DESCRIPTION
Fixes https://github.com/ungleich/cdist/issues/769

@telmich Can you verify with macos?

Sample run:
```
$ ./bin/cdist config -v -i ~/.cdist/manifest/test 185.203.112.26
INFO: 185.203.112.26: Starting configuration run
INFO: 185.203.112.26: Finished successful run in 6.55 seconds
$ cat ~/.cdist/cache/90cb04f9d8b4a35c89571b1c6fb9927c/explorer/disks
$ cat ~/.cdist/cache/90cb04f9d8b4a35c89571b1c6fb9927c/stderr/remote
Don't know how to list disks for X operating system, if you can please submit a patch
```
