### PR TITLE
__postgres_{database,role}: Run psql with --no-password (-w)

### DIFF
--- a/cdist/conf/type/__postgres_database/explorer/state
+++ b/cdist/conf/type/__postgres_database/explorer/state
@@ -34,7 +34,7 @@ esac
 
 name="$__object_id"
 
-if test -n "$(su - "$postgres_user" -c "psql postgres -tAc \"SELECT 1 FROM pg_database WHERE datname='$name'\"")"
+if test -n "$(su - "$postgres_user" -c "psql postgres -twAc \"SELECT 1 FROM pg_database WHERE datname='$name'\"")"
 then
     echo 'present'
 else

--- a/cdist/conf/type/__postgres_role/explorer/state
+++ b/cdist/conf/type/__postgres_role/explorer/state
@@ -34,7 +34,7 @@ esac
 
 name="$__object_id"
 
-if test -n "$(su - "$postgres_user" -c "psql postgres -tAc \"SELECT 1 FROM pg_roles WHERE rolname='$name'\"")"
+if test -n "$(su - "$postgres_user" -c "psql postgres -twAc \"SELECT 1 FROM pg_roles WHERE rolname='$name'\"")"
 then
     echo 'present'
 else

--- a/cdist/conf/type/__postgres_role/gencode-remote
+++ b/cdist/conf/type/__postgres_role/gencode-remote
@@ -55,7 +55,7 @@ case "$state_should" in
         [ -n "$password" ] && password="PASSWORD '$password'"
 
         cmd="CREATE ROLE $name WITH $password $booleans"
-        echo "su - '$postgres_user' -c \"psql postgres -c \\\"$cmd\\\"\""
+        echo "su - '$postgres_user' -c \"psql postgres -wc \\\"$cmd\\\"\""
     ;;
     absent)
         echo "su - '$postgres_user' -c \"dropuser \\\"$name\\\"\""


### PR DESCRIPTION
cdist does not work with interactive processes, so I think it's better to fail when manual password input is required.