### PR TITLE
fixup os_version explorer for sles 15

### DIFF
--- a/cdist/conf/explorer/os_version
+++ b/cdist/conf/explorer/os_version
@@ -60,7 +60,7 @@ case "$("$__explorer/os")" in
    slackware)
       cat /etc/slackware-version
    ;;
-   suse)
+   suse|sles)
       if [ -f /etc/os-release ]; then
         cat /etc/os-release
       else


### PR DESCRIPTION
Suse has no more SuSE-release as of SLES15, so the os explorer takes the os-release in to account:
`NAME="SLES"
VERSION="15-SP1"
VERSION_ID="15.1"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP1"
ID="sles"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:15:sp1"
`
Since there the ID= is checked, the result of os is no more suse, its now sles.