### PR TITLE
Trivial grammatical fixes to documentation

### DIFF
--- a/docs/src/cdist-bootstrap.rst
+++ b/docs/src/cdist-bootstrap.rst
@@ -25,7 +25,7 @@ people, have a look at `cdist best practice <cdist-best-practice.html>`_.
 Setup working directory and branch
 ----------------------------------
 I assume you have a fresh copy of the cdist tree in ~/cdist, cloned from
-one of the official urls (see `cdist quickstart <cdist-quickstart.html>`_ if you don't).
+one of the official URLs (see `cdist quickstart <cdist-quickstart.html>`_ if you don't).
 Entering the command "git branch" should show you "* master", which indicates
 you are on the **master** branch.
 

--- a/docs/src/cdist-cache.rst
+++ b/docs/src/cdist-cache.rst
@@ -59,7 +59,7 @@ typeorder
 
 Object cache overview
 ~~~~~~~~~~~~~~~~~~~~~
-Each object under :strong:`object` directory has its own structurue.
+Each object under :strong:`object` directory has its own structure.
 
 code-local
     code generated from gencode-local, present only if something is

--- a/docs/src/cdist-configuration.rst
+++ b/docs/src/cdist-configuration.rst
@@ -21,7 +21,7 @@ precedence. Configuration option value read from source with higher
 precedence will overwrite option value, if exists, read from source with
 lower precedence. That means that command-line option wins them all.
 
-Users can decide on the local conifguration file location. It can be either
+Users can decide on the local configuration file location. It can be either
 ~/.cdist.cfg or $XDG_CONFIG_HOME/cdist/cdist.cfg. Note that, if both exist,
 then ~/.cdist.cfg is used.
 

--- a/docs/src/cdist-install.rst
+++ b/docs/src/cdist-install.rst
@@ -9,7 +9,7 @@ Source Host
 
 This is the machine from which you will configure target hosts.
 
- * /bin/sh: A posix like shell (for instance bash, dash, zsh)
+ * /bin/sh: A POSIX like shell (for instance bash, dash, zsh)
  * Python >= 3.2
  * SSH client
  * sphinx (for building html docs and/or the man pages)
@@ -17,7 +17,7 @@ This is the machine from which you will configure target hosts.
 Target Hosts
 ~~~~~~~~~~~~
 
- * /bin/sh: A posix like shell (for instance bash, dash, zsh)
+ * /bin/sh: A POSIX like shell (for instance bash, dash, zsh)
  * SSH server
 
 Install cdist

--- a/docs/src/cdist-real-world.rst
+++ b/docs/src/cdist-real-world.rst
@@ -198,7 +198,7 @@ We require package uWSGI present in order to create **/etc/uwsgi/apps-enabled/$u
 Installation of uWSGI also creates configuration layout: **/etc/uwsgi/apps-enabled**.
 If this directory does not exist then **__file** type would error.
 We also use stdin as file content source. For details see `Input from stdin <cdist-type.html#input-from-stdin>`_.
-For feading stdin we use here-document (**<<** operator). It allows redirection of subsequent
+For feeding stdin we use here-document (**<<** operator). It allows redirection of subsequent
 lines read by the shell to the input of a command until a line containing only the delimiter
 and a newline, with no blank characters in between (EOF in our case).
 
@@ -546,7 +546,7 @@ we have changed our **wsgi.py** file uWSGI reloads the application.
 
 Our application selects and lists items from **items** table.
 
-Openning application
+Opening application
 ~~~~~~~~~~~~~~~~~~~~
 
 Finally try the application::

--- a/docs/src/cdist-upgrade.rst
+++ b/docs/src/cdist-upgrade.rst
@@ -14,7 +14,7 @@ To upgrade cdist in the current branch use
     make man
     export MANPATH=$MANPATH:$(pwd -P)/doc/man
 
-If you stay on a version branche (i.e. 1.0, 1.1., ...), nothing should break.
+If you stay on a version branch (i.e. 1.0, 1.1., ...), nothing should break.
 The master branch on the other hand is the development branch and may not be
 working, break your setup or eat the tree in your garden.
 
@@ -61,7 +61,7 @@ After that, you can go back and continue the upgrade:
 Update the python package
 -------------------------
 
-To upgrade to the lastet version do
+To upgrade to the latest version do
 
 .. code-block:: sh
 
@@ -158,7 +158,7 @@ Updating from 1.5 to 1.6
 * If you used **\_\_package_apt --preseed**, you need to use the new
   type **\_\_debconf_set_selections** instead.
 * The **\_\_package** types accepted either --state deinstalled or
-  --state uninstaaled. Starting with 1.6, it was made consistently
+  --state uninstalled. Starting with 1.6, it was made consistently
   to --state removed.
 
 Updating from 1.3 to 1.5

--- a/docs/src/cdist-why.rst
+++ b/docs/src/cdist-why.rst
@@ -21,7 +21,7 @@ Not only is shell scripting widely known by system engineers,
 but it is also a very powerful language. Here are some features
 which make daily work easy:
 
- * Configuration can react dynamicly on explored values
+ * Configuration can react dynamically on explored values
  * High level string manipulation (using sed, awk, grep)
  * Conditional support (**if, case**)
  * Loop support (**for, while**)
@@ -44,7 +44,7 @@ Cdist requires very little on a target system. Even better,
 in almost all cases all dependencies are usually fulfilled.
 Cdist does not require an agent or high level programming
 languages on the target host: it will run on any host that
-has a **ssh server running** and a posix compatible shell
+has a **ssh server running** and a POSIX compatible shell
 (**/bin/sh**). Compared to other configuration management systems,
 it does not require to open up an additional port.
 


### PR DESCRIPTION
This fixes some low hanging fruits found by speller in `docs/src/*.rst` files.