### PR TITLE
Handle missing apt lists

### DIFF
--- a/cdist/conf/type/__apt_update_index/gencode-remote
+++ b/cdist/conf/type/__apt_update_index/gencode-remote
@@ -20,7 +20,7 @@
 
 # run 'apt-get update' if anything in /etc/apt is newer then /var/lib/apt/lists
 cat << DONE
-if find /etc/apt -mindepth 1 -cnewer /var/lib/apt/lists | grep . > /dev/null; then
+if [ ! -d /var/lib/apt/lists ] || { find /etc/apt -mindepth 1 -cnewer /var/lib/apt/lists | grep . > /dev/null; }; then
    apt-get update || apt-get update
 fi
 DONE


### PR DESCRIPTION
On a newly imaged system, /var/lib/apt/lists may not exist. Check for
this case before comparing dates to the sources.